### PR TITLE
Enable 3D Cartesian. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ build*
 *.lai
 *.la
 *.a
+
+# Sublime workspace files
+*.sublime-workspace
+

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Nut is a C++ analog to the Haskell McPhD code. It currently has serial (master b
 
 This compact app captures many of the computational characteristics and challenges of Monte Carlo transport codes. Random number generation is handled by the Philox class of random number generators[1]. We use the Random123 implementation, [available from D. E. Shaw research](http://www.deshawresearch.com/downloads/download_random123.cgi/ "D. E. Shaw Research").
 
-Note that the 3D Cartesian mesh is currently less well-tested and used compared to the 1D Spherical mesh. We are working to bring the Cartesian mesh up to the same level of testing as the spherical. If you notice any flaws, please open an issue. Thanks!
+Note that the 3D Cartesian mesh is currently less well-tested and used compared to the 1D Spherical mesh. We are working to bring the Cartesian mesh up to the same level of testing as the spherical. If you notice any flaws, please open an issue. Also, we don't really have any 3D problems ready to go; thus the data input is lacking. If you would like to propose a problem, feel free to make a feature request. Thanks!
 
 NuT uses the [cmake build system](http://cmake.org/ "CMake").
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Nut is a C++ analog to the Haskell McPhD code. It currently has serial (master b
 
 This compact app captures many of the computational characteristics and challenges of Monte Carlo transport codes. Random number generation is handled by the Philox class of random number generators[1]. We use the Random123 implementation, [available from D. E. Shaw research](http://www.deshawresearch.com/downloads/download_random123.cgi/ "D. E. Shaw Research").
 
+Note that the 3D Cartesian mesh is currently less well-tested and used compared to the 1D Spherical mesh. We are working to bring the Cartesian mesh up to the same level of testing as the spherical. If you notice any flaws, please open an issue. Thanks!
+
 NuT uses the [cmake build system](http://cmake.org/ "CMake").
 
 Los Alamos National Security, LLC (LANS) owns the copyright to NuT, which it identifies internally as LA-CC-11-087. The license is BSD 3-Clause.
@@ -24,7 +26,7 @@ Random123 is implemented entirely in header files, so installation is minimal.
 1. Specify environment variables GTEST_DIR, RANDOM123_DIR, CC, and CXX. RANDOM123_DIR
 should point to the root of the installation. For example,
 
-   export GTEST_DIR=/path/to/gtest 
+   export GTEST_DIR=/path/to/gtest
 
    export RANDOM123_DIR=/home/me/downloads/deshaw/Random123-1.08
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,59 +1,10 @@
-# GCC etc
-# if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-#     include(FindOpenMP)
-#     find_package(OpenMP)
-#     if(OPENMP_FOUND)
-#         message(STATUS "open mp c flags:" ${OpenMP_C_FLAGS})
-#         message(STATUS "open mp CXX flags:" ${OpenMP_CXX_FLAGS})
-#     else()
-#         message(STATUS "no omp found!")
-#     endif()
-#
-# else()
-#
-#     message(STATUS "Custom configuring OMP for Clang")
-#     set(GOMP_LIB_PATH "/Users/tkelley/exports/gcc-5.2.0/lib")
-#     set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} ${GOMP_LIB_PATH})
-#     link_directories( ${GOMP_LIB_PATH})
-#
-#     set(OpenMP_C_FLAGS " -fopenmp")
-#     set(OpenMP_CXX_FLAGS " -fopenmp")
-#     set(OpenMP_FOUND TRUE)
-#
-# #     if(NOT DEFINED ENV ${C_INCLUDE_PATH})
-# #         C_INCLUDE_PATH=/Users/tkelley/wnld/llvm/omp/libomp_oss/build-clang-3.7.0/src
-# #     endif()
-# endif() # Clang
-
-
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-# set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${OpenMP_CXX_FLAGS}")
-# set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${OpenMP_CXX_FLAGS}")
-# set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${OpenMP_CXX_FLAGS}")
-# set(CMAKE_EXE_LINKER_FLAGS ${OpenMP_CXX_FLAGS})
-#
-
-# Avoiding setting flags directly
-# set(bh-3_COMPILE_FLAGS "  -O3 -fopenmp")
-
-# set(GOMP_LIB_PATH "/Users/tkelley/exports/gcc-5.2.0/lib")
-# set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} ${GOMP_LIB_PATH})
-# link_directories( ${GOMP_LIB_PATH})
-
-
-
-# Intel
-# set(bh-3_COMPILE_FLAGS " -openmp -xcore-avx2 -qopt-report5 -profile-loops=all ")
-
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${bh-3_COMPILE_FLAGS}")
-
-file(GLOB bh-3_SOURCES
+file(GLOB bh-3_support_SOURCES
     cl-args.cc
  )
 
 message( " PROJECT_SOURCE_DIR = " ${PROJECT_SOURCE_DIR} )
 
-add_library(bh-3_support ${bh-3_SOURCES})
+add_library(bh-3_support ${bh-3_support_SOURCES})
 
 include_directories ("${PROJECT_SOURCE_DIR}/lib")
 include_directories ("${BOOST_ROOT}/")
@@ -61,6 +12,10 @@ include_directories ("${BOOST_ROOT}/")
 add_executable(bh-3 bh-3.cc)
 
 target_link_libraries(bh-3 bh-3_support nut)
+
+add_executable(bh-3-cart bh-3-cartesian-3D.cc)
+
+target_link_libraries(bh-3-cart bh-3_support nut)
 
 # Build with DBC assertions turned on.
 # add_definitions(-DREQUIRE_ON)

--- a/apps/bh-3-cartesian-3D.cc
+++ b/apps/bh-3-cartesian-3D.cc
@@ -9,7 +9,7 @@
 // bh-3.cc further differs in attempting OpenMP & MPI execution, as well as
 // changing to the Philox CBRNG (Salmon et al, SC 2011).
 
-#include "Mesh.hh"
+#include "Mesh3DCar.hh"
 #include "RNG.hh"
 #include "constants.hh"
 #include "types.hh"
@@ -38,13 +38,17 @@
 #include <execinfo.h>
 // #include <omp.h>
 
+constexpr size_t dim = 3;
+
 using op_t = nut::Opacity<nut::geom_t>;
-constexpr size_t dim = 1;
 using Velocity_t = nut::Velocity<nut::geom_t, dim>;
 
 using Mesh_t =
-    nut::Sphere_1D<nut::cell_t, nut::geom_t, nut::bdy_types::descriptor>;
+    nut::Cartesian_3D<nut::cell_t, nut::geom_t, nut::bdy_types::descriptor>;
 using p_t = nut::Particle<nut::geom_t, nut::rng_t, Mesh_t::Vector>;
+
+// static
+
 using tally_t = nut::Tally<nut::geom_t, dim>;
 using census_t = nut::Census<p_t>;
 
@@ -334,8 +338,10 @@ get_mat_state(std::string const filename,
   // specified limits; also, get back the indices corresponding
   // to the limits.
   size_t llimitIdx(0), ulimitIdx(0);
-  Mesh_t mesh = nut::rows_to_mesh<nut::geom_t>(rows, llimit, ulimit, llimitIdx,
-                                               ulimitIdx);
+  Mesh_t mesh = nut::make_vacuum_bdy_c3();
+  // Mesh_t mesh = nut::rows_to_mesh<nut::geom_t>(rows, llimit, ulimit,
+  // llimitIdx,
+  //                                              ulimitIdx);
   Require(ulimitIdx >= llimitIdx, "invalid limits");
   size_t const nrows(ulimitIdx - llimitIdx);
   Require(mesh.n_cells() == nrows,

--- a/apps/cl-args.cc
+++ b/apps/cl-args.cc
@@ -5,146 +5,110 @@
 
 #include "cl-args.hh"
 
-#include <getopt.h>
+#include "RNG.hh"
+#include <cstdlib>
 #include <iostream>
 #include <sstream>
-#include <cstdlib>
-#include "RNG.hh"
+#include <getopt.h>
 
-args_t parseCL(int argc, char **argv)
+args_t
+parseCL(int argc, char ** argv)
 {
-    args_t args;
-    args.n_particles = 0;
-    args.inputF  = "";
-    args.outputF = "tally";
-    args.llimit  = 0.0;
-    args.ulimit  = 1e12;
-    args.chunkSz = 0;
-    args.dt      = 1e-7;
-    args.alpha   = 2.0;
-    args.seed    = 426356;
+  args_t args;
+  args.n_particles = 0;
+  args.inputF = "";
+  args.outputF = "tally";
+  args.llimit = 0.0;
+  args.ulimit = 1e12;
+  args.chunkSz = 0;
+  args.dt = 1e-7;
+  args.alpha = 2.0;
+  args.seed = 426356;
 
-    static const char *optString = "n:i:o:l:u:c:t:a:s:";
-    
-    const struct option longOpts[] = {
-        {"n-particles", required_argument, NULL, 'n'},
-        {"input",       required_argument, NULL, 'i'},
-        {"output",      required_argument, NULL, 'o'},
-        {"lower-limit", required_argument, NULL, 'l'},
-        {"upper-limit", required_argument, NULL, 'u'},
-        {"chunk-size",  required_argument, NULL, 'c'},
-        {"simulation-time", required_argument, NULL, 't'},
-        {"alpha",       required_argument, NULL, 'a'},
-        {"seed",        required_argument, NULL, 's'},
-        {NULL, no_argument, NULL, 0}
-    };
-    
-    int longidx(0);
-    int opt = getopt_long(argc,argv,optString,longOpts,&longidx);
-    // std::cout << __LINE__ << ": opt = " << opt << std::endl; 
-    while( opt != -1)
-    {
-        if(optarg == NULL)
-        {
-            std::cout << "optarg = NULL" << std::endl;
-        }
+  static const char * optString = "n:i:o:l:u:c:t:a:s:";
 
-        std::stringstream s(optarg);
-        // std::cout << "optarg = " << optarg << "; stringstream(optarg): "
-        //           << s.str() << "; longidx = " << longidx << std::endl;
-        switch(opt)
-        {
-        case 'n': 
-            s >> args.n_particles;
-            break;
-        case 'i':
-            args.inputF = optarg;
-            break;
-        case 'o':
-            args.outputF = optarg;
-            break;
-        case 'l':
-            s >> args.llimit;
-            break;
-        case 'u':
-            s >> args.ulimit;
-            break;
-        case 'c':
-            s >> args.chunkSz;
-            break;
-        case 't':
-            s >> args.dt;
-            break;
-        case 'a':
-            s >> args.alpha;
-            break;
-        case 's':
-            s >> args.seed;
-            break;
-        default:
-            std::stringstream errors("parseCL, unrecognized option: ");
-            errors << opt << std::endl;
-            std::cerr << __LINE__ << ":" << errors.str() << std::endl;
-            // throw(std::runtime_error(errors.str()));
-        }
-        opt = getopt_long(argc,argv,optString,longOpts,&longidx);
-    } // while(opt!= -1);
-    
-    // validation:
-    std::stringstream errors;
-    bool kill(false);
-    if(args.ulimit <= args.llimit)
-    {
-        errors << "lower limit (" << args.llimit 
-               << ") must be less than upper limit (" << args.ulimit
-               << ")" << std::endl;
-        kill = true;
+  const struct option longOpts[] = {
+      {"n-particles", required_argument, NULL, 'n'},
+      {"input", required_argument, NULL, 'i'},
+      {"output", required_argument, NULL, 'o'},
+      {"lower-limit", required_argument, NULL, 'l'},
+      {"upper-limit", required_argument, NULL, 'u'},
+      {"chunk-size", required_argument, NULL, 'c'},
+      {"simulation-time", required_argument, NULL, 't'},
+      {"alpha", required_argument, NULL, 'a'},
+      {"seed", required_argument, NULL, 's'},
+      {NULL, no_argument, NULL, 0}};
+
+  int longidx(0);
+  int opt = getopt_long(argc, argv, optString, longOpts, &longidx);
+  // std::cout << __LINE__ << ": opt = " << opt << std::endl;
+  while(opt != -1) {
+    if(optarg == NULL) { std::cout << "optarg = NULL" << std::endl; }
+
+    std::stringstream s(optarg);
+    // std::cout << "optarg = " << optarg << "; stringstream(optarg): "
+    //           << s.str() << "; longidx = " << longidx << std::endl;
+    switch(opt) {
+      case 'n': s >> args.n_particles; break;
+      case 'i': args.inputF = optarg; break;
+      case 'o': args.outputF = optarg; break;
+      case 'l': s >> args.llimit; break;
+      case 'u': s >> args.ulimit; break;
+      case 'c': s >> args.chunkSz; break;
+      case 't': s >> args.dt; break;
+      case 'a': s >> args.alpha; break;
+      case 's': s >> args.seed; break;
+      default:
+        std::stringstream errors("parseCL, unrecognized option: ");
+        errors << opt << std::endl;
+        std::cerr << __LINE__ << ":" << errors.str() << std::endl;
+        // throw(std::runtime_error(errors.str()));
     }
-    if(args.llimit < 0.0)
-    {
-        errors << "lower limit must be >= 0, setting to 0" << std::endl;
-        args.llimit = 0.0;
+    opt = getopt_long(argc, argv, optString, longOpts, &longidx);
+  }  // while(opt!= -1);
+
+  // validation:
+  std::stringstream errors;
+  bool kill(false);
+  if(args.ulimit <= args.llimit) {
+    errors << "lower limit (" << args.llimit
+           << ") must be less than upper limit (" << args.ulimit << ")"
+           << std::endl;
+    kill = true;
+  }
+  if(args.llimit < 0.0) {
+    errors << "lower limit must be >= 0, setting to 0" << std::endl;
+    args.llimit = 0.0;
+  }
+  if(args.dt < 0.0) {
+    errors << "sim time must be >= 0, you gave " << args.dt << std::endl;
+    kill = true;
+  }
+  if(0 == args.chunkSz) {
+    if(0 == args.n_particles) {
+      errors << "You must transport some particles: use -n <n> with <n> > 0.";
+      kill = true;
     }
-    if(args.dt < 0.0)
-    {
-        errors << "sim time must be >= 0, you gave " << args.dt << std::endl;
-        kill = true;
-    }
-    if(0 == args.chunkSz)
-    {
-        if(0 == args.n_particles)
-        {
-            errors << "You must transport some particles: use -n <n> with <n> > 0.";
-            kill = true;
-        }
-        args.chunkSz = args.n_particles;
-    }
+    args.chunkSz = args.n_particles;
+  }
 
-    std::cout << "Command line options:\n"
-              << "n: " << args.n_particles << "\n"
-              << "input file: "  << args.inputF   << "\n"
-              << "output file: " << args.outputF  << "\n"
-              << "llimit: "      << args.llimit   << "\n"
-              << "ulimit: "      << args.ulimit   << "\n"
-              << "chunkSize: "   << args.chunkSz  << "\n"
-              << "sim time: "    << args.dt       << "\n"
-              << "alpha: "       << args.alpha    << "\n"
-              << "seed: "        << args.seed     << "\n"
-        ;
+  std::cout << "Command line options:\n"
+            << "n: " << args.n_particles << "\n"
+            << "input file: " << args.inputF << "\n"
+            << "output file: " << args.outputF << "\n"
+            << "llimit: " << args.llimit << "\n"
+            << "ulimit: " << args.ulimit << "\n"
+            << "chunkSize: " << args.chunkSz << "\n"
+            << "sim time: " << args.dt << "\n"
+            << "alpha: " << args.alpha << "\n"
+            << "seed: " << args.seed << "\n";
 
-    if(errors.str() != "")
-    {
-        std::cerr << "CL parsing errors:\n" << errors.str() << std::endl;
-        if(kill)
-        {
-            exit(-1);
-        }
-    }
-    return args;
-} // parseCL
-
-
-
+  if(errors.str() != "") {
+    std::cerr << "CL parsing errors:\n" << errors.str() << std::endl;
+    if(kill) { exit(-1); }
+  }
+  return args;
+}  // parseCL
 
 // version
 // $Id$

--- a/lib/MatState.hh
+++ b/lib/MatState.hh
@@ -11,6 +11,7 @@
 #include "Assert.hh"
 #include "Density.hh"
 #include "Luminosity.hh"
+#include "Mesh.hh"
 #include "Temperature.hh"
 #include "Velocity.hh"
 #include "constants.hh"
@@ -20,7 +21,7 @@
 namespace nut {
 namespace P  // transformations specific to the p.1-p.7 file format
 {
-template <typename fp_t, size_t dim = 1>
+template <typename fp_t, size_t dim>
 struct state_entry_t {
   dens_t<fp_t> d;
   temp_t<fp_t> t;
@@ -28,13 +29,13 @@ struct state_entry_t {
   vel_t<dim> v;
 };
 
-template <typename fp_t, size_t dim = 1>
+template <typename fp_t, size_t dim>
 state_entry_t<fp_t, dim>
 row_to_state_entry(MatStateRowP<fp_t, dim> const & row);
 
 }  // namespace P
 
-template <typename fp_t, size_t dim = 1>
+template <typename fp_t, size_t dim>
 struct MatState {
   typedef Density<fp_t> Density_T;
   typedef Luminosity<fp_t> Luminosity_T;
@@ -104,14 +105,15 @@ extract_radius(MatStateRowP<fp_t, dim> const & row)
 /*!\brief: create a mesh within the given limits; identify the limiting
  * indices in the rows vector. The limiting indices use STL begin,end
  * convention. */
-template <typename mesh_t, typename fp_t, size_t dim = 1>
-mesh_t
-rows_to_mesh(std::vector<MatStateRowP<fp_t, dim> > const & rows,
-             fp_t const llimit,
-             fp_t const ulimit,
-             size_t & llimitIdx,
-             size_t & ulimitIdx)
+template <typename fp_t>
+Spherical_1D_Mesh rows_to_mesh(std::vector<MatStateRowP<fp_t, 1> > const & rows,
+                               fp_t const llimit,
+                               fp_t const ulimit,
+                               size_t & llimitIdx,
+                               size_t & ulimitIdx)
 {
+  using mesh_t = Spherical_1D_Mesh;
+  constexpr size_t dim = 1;
   // bool const  lims_ok = (ulimit > llimit);
   // Require(lims_ok , "rows_to_mesh: lower limit >= upper limit");
   size_t nrows = rows.size();
@@ -162,7 +164,7 @@ rows_to_mesh(std::vector<MatStateRowP<fp_t, dim> > const & rows,
 namespace P {
 /*! functions for extracting and converting particular quantities
  * from a MatStateRow */
-template <typename fp_t, size_t dim = 1>
+template <typename fp_t, size_t dim>
 dens_t<fp_t>
 row_to_rho(MatStateRowP<fp_t, dim> const & row)
 {
@@ -173,7 +175,7 @@ row_to_rho(MatStateRowP<fp_t, dim> const & row)
   return r;
 }
 
-template <typename fp_t, size_t dim = 1>
+template <typename fp_t, size_t dim>
 temp_t<fp_t>
 row_to_temp(MatStateRowP<fp_t, dim> const & row)
 {
@@ -183,7 +185,7 @@ row_to_temp(MatStateRowP<fp_t, dim> const & row)
   return t;
 }
 
-template <typename fp_t, size_t dim = 1>
+template <typename fp_t, size_t dim>
 lum_t<fp_t>
 row_to_lum(MatStateRowP<fp_t, dim> const & row)
 {
@@ -194,7 +196,7 @@ row_to_lum(MatStateRowP<fp_t, dim> const & row)
   return l;
 }
 
-template <typename fp_t, size_t dim = 1>
+template <typename fp_t, size_t dim>
 vel_t<dim>
 row_to_vel(MatStateRowP<fp_t, dim> const & row)
 {

--- a/lib/Mesh.hh
+++ b/lib/Mesh.hh
@@ -29,6 +29,7 @@ public:
   static const size_t dim = 1;
 
   typedef geometry_t geom_t;
+  using Vector = Vec_T<geom_t, 1>;
   typedef bdy_descriptor_t bdy_desc_t;
   typedef std::vector<geom_t> vb;
   typedef std::vector<bdy_desc_t> vbd;
@@ -92,14 +93,15 @@ public:
     return result;
   }  // cell_across_face
 
-  geom_t sample_position(geom_t const urd, cell_t const cell) const
+  template <typename rng_t>
+  geom_t sample_position(rng_t & rng, cell_t const cell) const
   {
     extents_t extents = this->cell_extents(cell);
     geom_t const lo = extents.first;
     geom_t const hi = extents.second;
     geom_t const lo3 = lo * lo * lo;
     geom_t const hi3 = hi * hi * hi;
-    geom_t const r = std::pow(lo3 + (hi3 - lo3) * urd, 1.0 / 3.0);
+    geom_t const r = std::pow(lo3 + (hi3 - lo3) * rng.random(), 1.0 / 3.0);
     return r;
   }
 
@@ -111,7 +113,7 @@ public:
   }
 
   /*!\brief type of cell boundary */
-  bdy_desc_t bdy_type(cell_t const c, cell_t const face) const
+  bdy_desc_t get_bdy_type(cell_t const c, cell_t const face) const
   {
     cell_t const idx = make_idx(c, m_ncells);
     cell_t const fidx = face_to_index(face);
@@ -246,16 +248,16 @@ public:
     return d2b;
   }  // dist_to_bdy_impl
 
-  static inline EandOmega<1> LT_to_comoving(vec_t<1> const v_lab,
-                                            geom_t const & e_lab,
-                                            vec_t<1> const & omega_lab)
+  static EandOmega<1> LT_to_comoving(vec_t<1> const v_lab,
+                                     geom_t const & e_lab,
+                                     vec_t<1> const & omega_lab)
   {
     return spec_1D::LT_to_comoving_sphere1D(v_lab.v[0], e_lab, omega_lab);
   }  // LT_to_comoving
 
-  static EandOmega<1> inline LT_to_lab(vec_t<1> const v_lab,
-                                       geom_t const & e_com,
-                                       vec_t<1> const & omega_com)
+  static EandOmega<1> LT_to_lab(vec_t<1> const v_lab,
+                                geom_t const & e_com,
+                                vec_t<1> const & omega_com)
   {
     return spec_1D::LT_to_lab_sphere1D(v_lab.v[0], e_com, omega_com);
   }
@@ -272,6 +274,8 @@ public:
   }
 
 };  // Sphere_1D
+
+using Spherical_1D_Mesh = Sphere_1D<cell_t, geom_t, bdy_types::descriptor>;
 
 }  // namespace nut
 

--- a/lib/Mesh3DCar.hh
+++ b/lib/Mesh3DCar.hh
@@ -13,6 +13,7 @@
 #include "soft_equiv.hh"
 #include "types.hh"
 #include "utilities.hh"
+#include "utilities_io.hh"
 #include <cmath>
 #include <ostream>
 #include <string>
@@ -38,17 +39,18 @@ template <typename cell_t,
           typename bdy_descriptor_t = nut::bdy_types::descriptor>
 struct Cartesian_3D {
 public:
+  // types and constants
   static const size_t dim = 3;
 
-  typedef geometry_t geom_t;
-  typedef geom_t const & gcr;
-  // typedef Vec_T<geom_t,3> vec_t;
+  using geom_t = geometry_t;
+  using gcr = geom_t const &;
+  using Vector = Vec_T<geom_t, dim>;
 
-  typedef bdy_descriptor_t bdy_desc_t;
-  typedef std::vector<geom_t> vb;
-  typedef std::vector<bdy_desc_t> vbd;
-  typedef std::pair<geom_t, geom_t> extents_t;
-  typedef ijk_t<cell_t> ijk_T;
+  using bdy_desc_t = bdy_descriptor_t;
+  using vb = std::vector<geom_t>;
+  using vec_bdy_descs = std::vector<bdy_desc_t>;
+  using extents_t = std::pair<geom_t, geom_t>;
+  using ijk_T = ijk_t<cell_t>;
 
   static const cell_t vac_cell = cell_t(-1);
   static constexpr geom_t huge = 1e300;
@@ -61,10 +63,10 @@ public:
 
   enum face_t {
     low_x = 0, /* y-z plane */
-    high_x,    /* y-z plane */
     low_y,     /* x-z plane */
-    high_y,    /* x-z plane */
     low_z,     /* x-y plane */
+    high_x,    /* y-z plane */
+    high_y,    /* x-z plane */
     high_z     /* x-y plane */
   };
 
@@ -77,108 +79,17 @@ public:
     d_to_b_t(geom_t const d_, face_t const f_) : d(d_), face(f_) {}
   };
 
-  /** \brief Convert a lexical cell index to (i,j,k) */
-  inline ijk_T mkIJK(cell_t const idx) const
-  {
-    ijk_T ijk((idx % m_nx), (idx / m_nx % m_ny), (idx / m_nx / m_ny));
-    return std::move(ijk);
-  }
-  /** \brief Convert Cartesian index to lexical. */
-  inline cell_t toIndex(ijk_T const ijk) const
-  {
-    return ijk.i + ijk.j * m_nx + ijk.k * m_nx * m_ny;
-  }
-
-  static void printIJK(ijk_T const & ijk)
-  {
-    std::cout << ijk.i << "," << ijk.j << "," << ijk.k << "\n";
-  }
-
-  static inline cell_t getBCIndex(cell_t const i1,
-                                  cell_t const i2,
-                                  cell_t const n1)
-  {
-    return i1 + n1 * i2;
-  }
-
-  static inline cell_t getBCOffset(face_t const face,
-                                   cell_t const nx,
-                                   cell_t const ny,
-                                   cell_t const nz)
-  {
-    cell_t offset(0);
-    /* The offset for a given face is the sum of all the
-     * previous offsets, so yes, fall through cases. */
-    switch(face) {
-      case high_x: offset += ny * nz;
-      case low_x: offset += nx * nz;
-      case high_y: offset += nx * nz;
-      case low_y: offset += nx * ny;
-      case high_z: offset += nx * ny;
-      case low_z: offset += 0;
-    }
-    return offset;
-  }
-
-  /** This uses a cheap and dirty way of storing boundary conditions *
-   * for a rectangular solid. BCs are loaded into the vector of *
-   * boundary descriptors in the following order:
-   * low-z plane (x-y)
-   * high-z plane
-   * low-y plane (x-z)
-   * high-y plane
-   * low-x plane (y-z)
-   * high-x plane
-   *
-   * In each plane, b.c.'s are loaded with the lower coordinate
-   * running first (contiguous). To recover the boundary condition
-   * for a cell, first convert to i,j,k, then use the correct offset
-   * and the correct two indices.
-   */
-  bdy_desc_t getBC(face_t const face, cell_t const cidx) const
-  {
-    cell_t const offset(getBCOffset(face, m_nx, m_ny, m_nz));
-    ijk_T const ijk(mkIJK(cidx));
-    cell_t const i1 = (face >= low_y) ? ijk.i : ijk.k;
-    cell_t const i2 = (face <= high_y) ? ijk.k : ijk.k;
-    cell_t const n1 = (face <= high_y) ? m_nx : m_ny;
-    cell_t const index = offset + getBCIndex(i1, i2, n1);
-    return m_bds[index];
-  }
+public:
+  // Interface
 
   // ctor
-  Cartesian_3D(geom_t const dx,
-               cell_t const nx,
-               geom_t const dy,
+  Cartesian_3D(cell_t const nx,
                cell_t const ny,
-               geom_t const dz,
                cell_t const nz,
-               vbd const bds)
-      : m_dx(dx),
-        m_nx(nx),
-        m_dy(dy),
-        m_ny(ny),
-        m_dz(dz),
-        m_nz(nz),
-        m_ncells(nx * ny * nz),
-        m_bds(bds)
-  {
-    nut::Require(m_bds.size() == 2 * nx * ny + 2 * nx * nz + 2 * ny * nz,
-                 "Cartesian_3D: Must have correct number of"
-                 " boundary descriptors");
-    auto gtg = [](geom_t const x, geom_t const e, const char * s) {
-      return nut::GreaterThan(x, e, s);
-    };
-    auto gtc = [](cell_t const x, cell_t const e, const char * s) {
-      return nut::GreaterThan(x, e, s);
-    };
-    gtg(dx, 0.0, "Cartesian_3D: x cell spacing must be > 0");
-    gtg(dy, 0.0, "Cartesian_3D: y cell spacing must be > 0");
-    gtg(dz, 0.0, "Cartesian_3D: z cell spacing must be > 0");
-    gtc(nx, 0, "Cartesian_3D: nx must be > 0");
-    gtc(ny, 0, "Cartesian_3D: ny must be > 0");
-    gtc(nz, 0, "Cartesian_3D: nz must be > 0");
-  }
+               geom_t const dx,
+               geom_t const dy,
+               geom_t const dz,
+               vec_bdy_descs const bds);
 
   cell_t n_cells() const { return m_ncells; }
 
@@ -188,12 +99,132 @@ public:
     geom_t vol = m_dx * m_dy * m_dz;
     return vol;
   }  // volume
+
+  /** Is a cell a boundary for the relevant face? */
+  inline bool isBoundary(cell_t const cidx, face_t const face) const;
+
+  /*!\brief which cell is across a face. Computed.
+   *
+   * \param cell: 0 < cell <= n_cells
+   * \param face: enum instances
+   */
+  inline cell_t cell_across_face(cell_t const cell, face_t face) const;
+
+  /** \brief Sample a position in a cell. */
+  template <typename RNG_T>
+  inline Vector sample_position(RNG_T & rng, cell_t const cell) const;
+
+  /** Sample a direction uniformly on the unit sphere. */
+  template <typename RNG_T>
+  static Vector sample_direction(RNG_T & rng);
+
+  /*!\brief get the lower and upper bounds of a cell in the direction indicated
+   * by the face. For example, passing low or high x gives the x direction. *
+   * 0 < cell <= n_cells                              */
+  extents_t cell_extents(cell_t const cell, dir_t const d) const;
+
+  /*!\brief calculate new coordinates and new direction cosines at a given
+   *        distance along old direction cosines.  */
+  coord_t new_coordinate(vec_t<3> const & oldx,
+                         vec_t<3> const & oldomega,
+                         geom_t const distance) const;
+
+  /** Distance-to-boundary. This is possibly not the most elegant
+   * or efficient or vectorizable implementation. */
+  inline d_to_b_t distance_to_bdy(coord_t const & crd, cell_t const cell) const;
+
+  inline d_to_b_t distance_to_bdy(vec_t<3> const & x,
+                                  vec_t<3> const & omega,
+                                  cell_t const cell) const;
+
+  /** This stores boundary conditions for a rectangular solid mesh.
+   * BCs are loaded into the vector of
+   * boundary descriptors in the following order:
+   * low-x plane (y-z)
+   * high-x plane
+   * low-y plane (x-z)
+   * high-y plane
+   * low-z plane (x-y)
+   * high-z plane
+   *
+   * In each plane, b.c.'s are loaded with the lower coordinate
+   * running first (contiguous). To recover the boundary condition
+   * for a cell, first convert to i,j,k, then use the correct offset
+   * and the correct two indices.
+   */
+  inline bdy_desc_t getBC(face_t const face, cell_t const cidx) const;
+
+  /*!\brief type of cell boundary */
+  inline bdy_desc_t get_bdy_type(cell_t const c, cell_t const face) const;
+
+  /** Transform energy and momentum to the frame that is moving with
+   * velocity v in the lab frame. v is the velocity of the co-moving
+   * frame in the lab frame. */
+  static EandOmega<3> LT_to_comoving(vec_t<3> const & v_lab,
+                                     geom_t const & e_lab,
+                                     vec_t<3> const & omega_lab)
+  {
+    return spec_3D_Cartesian::LT_to_comoving(v_lab, e_lab, omega_lab);
+  }  // LT_to_comoving
+
+  /** Transform energy and momentum to the lab frame from the
+      co-moving frame. Note that v is the velocity of the co-moving
+      frame in the lab frame (not the velocity of the lab frame in c-m.
+      This accomodates storing all the material velocities in the
+      lab frame. */
+  static EandOmega<3> LT_to_lab(vec_t<3> const & v_lab,
+                                geom_t const & e_com,
+                                vec_t<3> const & omega_com)
+  {
+    return spec_3D_Cartesian::LT_to_comoving(v_lab, e_com, omega_com);
+  }  // LT_to_comoving
+
+private:
+  // state
+  cell_t const m_nx;
+  cell_t const m_ny;
+  cell_t const m_nz;
+  geom_t const m_dx;
+  geom_t const m_dy;
+  geom_t const m_dz;
+
+  cell_t const m_ncells;
+  vec_bdy_descs m_bdy_descs;
+
+  // implementation
+private:
+  /** Get the grid spacing in the specified direction*/
+  inline geom_t getDeltaCoord(dir_t const d) const
+  {
+    geom_t res(0);
+    switch(d) {
+      case X: res = m_dx; break;
+      case Y: res = m_dy; break;
+      case Z: res = m_dz; break;
+    }
+    return res;
+  }
+
+  static inline ijk_T updateIJK(ijk_T const & old,
+                                cell_t const newIdx,
+                                face_t const f)
+  {
+    ijk_T out(old.i, old.j, old.k);
+    switch(f % 3) {
+      case 0: out.i = newIdx; break;
+      case 1: out.j = newIdx; break;
+      case 2: out.k = newIdx; break;
+      default: Require(false, "Mesh3DCar::updateIJK: face out of range!");
+    }
+    return out;
+  }
+
   /** \brief True if face is on the high side. */
-  static inline bool isHigh(face_t const face) { return face % 2; }
+  static inline bool isHigh(face_t const face) { return face / 3; }
 
   static inline cell_t getIJKComp(ijk_T const & ijk, face_t const face)
   {
-    return getIJKComp(ijk, dir_t(face / 2));
+    return getIJKComp(ijk, dir_t(face % 3));
   }
   /** \brief Get copy of Cartesian component. */
   static inline cell_t getIJKComp(ijk_T const & ijk, dir_t const d)
@@ -215,250 +246,53 @@ public:
     return m_nz;
   }
 
-  /** Is a cell a boundary for the relevant face? */
-  inline bool isBoundary(cell_t const cidx, face_t const face) const
+  /** \brief Convert a lexical cell index to (i,j,k) */
+  inline ijk_T mkIJK(cell_t const idx) const
   {
-    ijk_T const ijk(mkIJK(cidx));
-    return isBoundary(ijk, face);
+    ijk_T ijk((idx % m_nx), (idx / m_nx % m_ny), (idx / m_nx / m_ny));
+    return ijk;
+  }
+  /** \brief Convert Cartesian index to lexical. */
+  inline cell_t toIndex(ijk_T const ijk) const
+  {
+    return ijk.i + ijk.j * m_nx + ijk.k * m_nx * m_ny;
   }
 
-  inline bool isBoundary(ijk_T const & ijk, face_t const face) const
+  static void printIJK(ijk_T const & ijk)
   {
-    bool isBound(false);
-    cell_t const idx = getIJKComp(ijk, face);
-    bool const ishigh(isHigh(face));
-    if(0 == idx && !ishigh)
-      isBound = true;
-    else {
-      cell_t ndir = getDimSize(face);
-      if(ndir - 1 == idx && ishigh) isBound = true;
+    std::cout << ijk.i << "," << ijk.j << "," << ijk.k << "\n";
+  }
+
+  static inline cell_t getBCIndex(cell_t const i1,
+                                  cell_t const i2,
+                                  cell_t const n1)
+  {
+    return i1 + n1 * i2;
+  }
+
+public:
+  /* This is forced to be public, b/c external functions use it, and it has
+   * to be a member because of the types. */
+  static inline cell_t getBCOffset(face_t const face,
+                                   cell_t const nx,
+                                   cell_t const ny,
+                                   cell_t const nz)
+  {
+    cell_t offset(0);
+    /* The offset for a given face is the sum of all the previous
+     * offsets, so yes, fall through cases. That is, read this
+     * from bottom to top, stopping at the face of interest. */
+    switch(face) {
+      case high_z: offset += nx * ny;  // + nx * ny for low-z
+      case low_z: offset += nx * nz;   // + nx * nz for high-y
+      case high_y: offset += nx * nz;  // + nx * nz for low-y
+      case low_y: offset += ny * nz;   // + ny * nz offsets for high-X
+      case high_x: offset += ny * nz;  // there were ny * nz offsets for low-X
+      case low_x: offset += 0;         // offsets start at 0 with lox-x
     }
-    return isBound;
-  }
-
-  static inline ijk_T updateIJK(ijk_T const & old,
-                                cell_t const newIdx,
-                                face_t const f)
-  {
-    ijk_T out(old.i, old.j, old.k);
-    switch(f / 2) {
-      case 0: out.i = newIdx; break;
-      case 1: out.j = newIdx; break;
-      case 2: out.k = newIdx; break;
-      default: Require(false, "Mesh3DCar::updateIJK: face out of range!");
-    }
-    return std::move(out);
-  }
-
-  /*!\brief which cell is across a face. Computed.
-   *
-   * \param cell: 0 < cell <= n_cells
-   * \param face: enum instances
-   */
-  cell_t cell_across_face(cell_t const cell, face_t face) const
-  {
-    // convert to i,j,k
-    ijk_T const ijkIn(mkIJK(cell));
-    cell_t result(cell_t(0));
-    // add/subtract 1 from appropriate index
-    if(!isBoundary(cell, face)) {
-      cell_t inew = getIJKComp(ijkIn, face) + (isHigh(face) ? 1 : (-1));
-      ijk_T updd = updateIJK(ijkIn, inew, face);
-      result = toIndex(updd);
-    }
-    else {
-      // otherwise, consult boundary condition
-      bdy_desc_t const bd = this->getBC(face, cell);
-      switch(bd) {
-        case nut::bdy_types::R: result = cell; break;
-        case nut::bdy_types::V: result = vac_cell; break;
-        default:
-          std::stringstream errstr;
-          errstr << "Mesh3DCar::cell_across_face: "
-                 << "unexpected boundary descriptor " << bd;
-      }
-    }
-    return result;
-  }  // cell_across_face
-
-  /** \brief Sample a position in a cell. */
-  template <typename RNG_T>
-  inline coord_t sample_position(RNG_T & rng, cell_t const cell) const
-  {
-    coord_t coord;
-    extents_t xs = cell_extents(cell, X);
-    coord.x.v[0] = xs.first + rng.random() * (xs.second - xs.first);
-    extents_t ys = cell_extents(cell, Y);
-    coord.x.v[1] = ys.first + rng.random() * (ys.second - ys.first);
-    extents_t zs = cell_extents(cell, Z);
-    coord.x.v[2] = zs.first + rng.random() * (zs.second - zs.first);
-    coord.omega = sample_direction(rng);
-    return std::move(coord);
-  }  // sample_position
-
-  /** Sample a direction uniformly on the unit sphere. */
-  template <typename RNG_T>
-  static inline vec_t<3> sample_direction(RNG_T & rng)
-  {
-    geom_t const ctheta = geom_t(2) * rng.random() - geom_t(1);
-    geom_t const phi = geom_t(2) * pi * rng.random();
-    geom_t const stheta = std::sqrt(1 - ctheta * ctheta);
-    geom_t const cphi = std::cos(phi);
-    geom_t const sphi = std::sin(phi);
-    vec_t<3> v;
-    v.v = {{stheta * cphi, stheta * sphi, ctheta}};
-    return v;
-  }
-
-  /** Get the grid spacing in the specified direction*/
-  inline geom_t getDeltaCoord(dir_t const d) const
-  {
-    geom_t res(0);
-    switch(d) {
-      case X: res = m_dx; break;
-      case Y: res = m_dy; break;
-      case Z: res = m_dz; break;
-    }
-    return res;
-  }
-
-  /*!\brief get the lower and upper bounds of a cell in the direction indicated
-   * by the face. For example, passing low or high x gives the x direction. *
-   * 0 < cell <= n_cells                              */
-  extents_t cell_extents(cell_t const cell, dir_t const d) const
-  {
-    ijk_T ijk(mkIJK(cell));
-    cell_t const idx = getIJKComp(ijk, d);
-    cell_t const dc = getDeltaCoord(d);
-    geom_t clow = idx * dc;
-    geom_t chigh = (idx + 1) * dc;
-    return extents_t(clow, chigh);
-    // return extents_t(m_bdys[cell-1],m_bdys[cell]);
-  }
-
-  /*!\brief calculate new coordinates and new direction cosines at a given
-   *        distance along old direction cosines.  */
-  coord_t new_coordinate(coord_t const oldc, geom_t const distance) const
-  {
-    return this->new_coordinate(oldc.x, oldc.omega, distance);
-  }
-
-  coord_t new_coordinate(vec_t<3> const & oldx,
-                         vec_t<3> const & oldomega,
-                         geom_t const distance) const
-  {
-    coord_t newc;
-    newc.x.v[0] = oldx.v[0] + distance * oldomega.v[0];
-    newc.x.v[1] = oldx.v[1] + distance * oldomega.v[1];
-    newc.x.v[2] = oldx.v[2] + distance * oldomega.v[2];
-    newc.omega.v[0] = oldomega.v[0];
-    newc.omega.v[1] = oldomega.v[1];
-    newc.omega.v[2] = oldomega.v[2];
-    return std::move(newc);
-  }  // new_coordinate
-
-  /** Distance-to-boundary. This is possibly not the most elegant
-   * or efficient or vectorizable implementation. */
-  d_to_b_t distance_to_bdy(coord_t const crd, cell_t const cell) const
-  {
-    return this->distance_to_bdy(crd.x, crd.omega, cell);
-  }
-
-  d_to_b_t distance_to_bdy(vec_t<3> const & x,
-                           vec_t<3> const & omega,
-                           cell_t const cell) const
-  {
-    extents_t const xs = cell_extents(cell, X);
-    d_to_b_t const dx =
-        omega.v[0] > 0
-            ? d_to_b_t((xs.second - x.v[0]) / omega.v[0], high_x)
-            : omega.v[0] < 0 ? d_to_b_t((xs.first - x.v[0]) / omega.v[0], low_x)
-                             : d_to_b_t(huge, high_x);
-    extents_t const ys = cell_extents(cell, Y);
-    d_to_b_t const dy =
-        omega.v[1] > 0
-            ? d_to_b_t((ys.second - x.v[1]) / omega.v[1], high_y)
-            : omega.v[1] < 0 ? d_to_b_t((ys.first - x.v[1]) / omega.v[1], low_y)
-                             : d_to_b_t(huge, high_y);
-
-    extents_t const zs = cell_extents(cell, Z);
-    d_to_b_t const dz =
-        omega.v[2] > 0
-            ? d_to_b_t((zs.second - x.v[2]) / omega.v[2], high_z)
-            : omega.v[2] < 0 ? d_to_b_t((zs.first - x.v[2]) / omega.v[2], low_z)
-                             : d_to_b_t(huge, high_z);
-
-    auto comp = [](d_to_b_t const * d1, d_to_b_t const * d2) {
-      return (d1->d) < (d2->d) ? true : false;
-    };
-
-    d_to_b_t const * result = std::min(&dx, std::min(&dy, &dz, comp), comp);
-    return std::move(*result);
-  }
-
-  geom_t const m_dx;
-  cell_t const m_nx;
-  geom_t const m_dy;
-  cell_t const m_ny;
-  geom_t const m_dz;
-  cell_t const m_nz;
-
-  cell_t const m_ncells;
-  vbd m_bds;
-
-  struct EAndOmega {
-    vec_t<3> omega;
-    geom_t e;
-  };
-
-  static geom_t inline gamma(vec_t<3> const v)
-  {
-    return 1.0 / std::sqrt(1 - dot(v, v) / (c * c));
-  }
-
-  /** Transform energy and momentum to the frame that is moving with
-   * velocity v in the lab frame. v is the velocity of the co-moving
-   * frame in the lab frame. */
-  static EandOmega<3> inline LT_to_comoving(vec_t<3> const & v_lab,
-                                            geom_t const & e_lab,
-                                            vec_t<3> const & omega_lab)
-  {
-    EAndOmega res;
-    geom_t const vdo = dot(v_lab, omega_lab);
-    geom_t const gam = gamma(v_lab);
-    geom_t const goc = gam / c;
-    geom_t const fac = 1 - goc * vdo / (gam + 1);
-    res.e = gam * e_lab * (1 - vdo / c);
-    geom_t const eoec = e_lab / res.e;  // E/E_com
-    res.omega.v[0] = eoec * (omega_lab.v[0] - goc * v_lab.v[0] * fac);
-    res.omega.v[1] = eoec * (omega_lab.v[1] - goc * v_lab.v[1] * fac);
-    res.omega.v[2] = eoec * (omega_lab.v[2] - goc * v_lab.v[2] * fac);
-    return std::move(res);
-  }  // LT_to_comoving
-
-  /** Transform energy and momentum to the lab frame from the
-      co-moving frame. Note that v is the velocity of the co-moving
-      frame in the lab frame (not the velocity of the lab frame in c-m.
-      This accomodates storing all the material velocities in the
-      lab frame. */
-  static EandOmega<3> inline LT_to_lab(vec_t<3> const & v_lab,
-                                       geom_t const & e_com,
-                                       vec_t<3> const & omega_com)
-  {
-    EandOmega<3> res;
-    geom_t const vdo = dot(v_lab, omega_com);
-    geom_t const gam = gamma(v_lab);
-    geom_t const goc = gam / c;
-    geom_t const fac = 1 + goc * vdo / (gam + 1);
-    res.first = gam * e_com * (1 + vdo / c);
-    geom_t const eoec = e_com / res.first;  // E/E_com
-    res.second.v[0] = eoec * (omega_com.v[0] + goc * v_lab.v[0] * fac);
-    res.second.v[1] = eoec * (omega_com.v[1] + goc * v_lab.v[1] * fac);
-    res.second.v[2] = eoec * (omega_com.v[2] + goc * v_lab.v[2] * fac);
-    return res;
-  }  // LT_to_comoving
-
-};  // Cartesian_3D
+    return offset;
+  }  // getBCOffset
+};   // struct Cartesian_3D
 
 /** \brief Make a plane's worth of reflecting b.c.'s; helper for mkReflectBCs.
  */
@@ -491,32 +325,37 @@ mkReflectBCs(std::vector<bdy_descriptor_t> & bds,
              cell_t const ny,
              cell_t const nz)
 {
-  bdy_descriptor_t const ref(nut::bdy_types::R);
   cell_t const n_bs = 2 * nx * ny + 2 * nx * nz + 2 * ny * nz;
-  if(n_bs != bds.size()) { bds.resize(n_bs); }
+  bdy_descriptor_t const reflect(nut::bdy_types::R);
+  if(n_bs != bds.size()) { bds.resize(n_bs, reflect); }
   cell_t offset(0);
-  // low z bounds
-  offset += mkPlaneBC(bds, nx, ny, offset, ref);
-  // high z bounds
-  Require(offset == mesh_t::getBCOffset(mesh_t::high_z, nx, ny, nz),
-          "offset not correct");
-  offset += mkPlaneBC(bds, nx, ny, offset, ref);
-  // low y bounds
-  Require(offset == mesh_t::getBCOffset(mesh_t::low_y, nx, ny, nz),
-          "mkReflectBCs: offset not correct");
-  offset += mkPlaneBC(bds, nx, nz, offset, ref);
-  // high y bounds
-  Require(offset == mesh_t::getBCOffset(mesh_t::high_y, nx, ny, nz),
-          "mkReflectBCs: offset not correct");
-  offset += mkPlaneBC(bds, nx, nz, offset, ref);
   // low x bounds
   Require(offset == mesh_t::getBCOffset(mesh_t::low_x, nx, ny, nz),
-          "mkReflectBCs: offset not correct");
-  offset += mkPlaneBC(bds, ny, nz, offset, ref);
+          "mkReflectBCs: offset not correct 514");
+  offset += mkPlaneBC(bds, ny, nz, offset, reflect);
   // high x bounds
   Require(offset == mesh_t::getBCOffset(mesh_t::high_x, nx, ny, nz),
-          "mkReflectBCs: offset not correct");
-  offset += mkPlaneBC(bds, ny, nz, offset, ref);
+          "mkReflectBCs: offset not correct 518");
+  offset += mkPlaneBC(bds, ny, nz, offset, reflect);
+  // low y bounds
+  Require(offset == mesh_t::getBCOffset(mesh_t::low_y, nx, ny, nz),
+          "mkReflectBCs: offset not correct 522");
+  offset += mkPlaneBC(bds, nx, nz, offset, reflect);
+  // high y bounds
+  Require(offset == mesh_t::getBCOffset(mesh_t::high_y, nx, ny, nz),
+          "mkReflectBCs: offset not correct 526");
+  offset += mkPlaneBC(bds, nx, nz, offset, reflect);
+  // low z bounds
+  Require(offset == mesh_t::getBCOffset(mesh_t::low_z, nx, ny, nz),
+          "mkReflectBCs: offset not correct 530");
+  offset += mkPlaneBC(bds, nx, ny, offset, reflect);
+  // high z bounds
+  Require(offset == mesh_t::getBCOffset(mesh_t::high_z, nx, ny, nz),
+          "mkReflectBCs: offset not correct 534");
+  offset += mkPlaneBC(bds, nx, ny, offset, reflect);
+
+  Require(offset == bds.size(),
+          "mkReflectBCs: offset did not account for all entries");
   return;
 }
 
@@ -563,7 +402,25 @@ mkLowRefHighVacBounds(std::vector<nut::bdy_types::descriptor> & bds,
   return;
 }  // mkLowRefHighVacBounds
 
+// useful typedef
+using Cartesian_3D_Mesh = Cartesian_3D<cell_t, geom_t>;
+
+Cartesian_3D_Mesh
+make_vacuum_bdy_c3()
+{
+  cell_t const nx = 3, ny = 5, nz = 7;
+  geom_t const dx = 1.0, dy = 2.0, dz = 3.0;
+  Cartesian_3D_Mesh::vec_bdy_descs bds{};
+  Cartesian_3D_Mesh mesh(nx, ny, nz, dx, dy, dz, bds);
+  return mesh;
+}
+
 }  // namespace nut
+
+// introduce inline template definitions
+#define ALLOWED_TO_INCLUDE_MESH3D_CAR_I_HH
+#include "Mesh3DCar.i.hh"
+#undef ALLOWED_TO_INCLUDE_MESH3D_CAR_I_HH
 
 #endif
 

--- a/lib/Mesh3DCar.i.hh
+++ b/lib/Mesh3DCar.i.hh
@@ -1,0 +1,259 @@
+// Mesh3DCar.i.hh
+// T. M. Kelley
+// May 14, 2019
+// (c) Copyright 2019 Triad National Security, all rights reserved
+
+/* Implementations for Mesh3DCar methods */
+
+#ifndef ALLOWED_TO_INCLUDE_MESH3D_CAR_I_HH
+#error "Do not include Mesh3DCar.i.hh direectly: instead include Mesh3DCar.hh"
+#endif
+
+#pragma once
+
+namespace nut {
+
+template <typename cell_t, typename geometry_t, typename bdy_descriptor_t>
+bdy_descriptor_t
+Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::get_bdy_type(
+    cell_t const c,
+    cell_t const face) const
+{
+  cell_t const idx = make_idx(c, m_ncells);
+  return m_bdy_descs[idx + face];
+}
+
+template <typename cell_t, typename geometry_t, typename bdy_descriptor_t>
+typename Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::d_to_b_t
+    Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::distance_to_bdy(
+        vec_t<3> const & x,
+        vec_t<3> const & omega,
+        cell_t const cell) const
+{
+  extents_t const xs = cell_extents(cell, X);
+  d_to_b_t const dx =
+      omega.v[0] > 0
+          ? d_to_b_t((xs.second - x.v[0]) / omega.v[0], high_x)
+          : omega.v[0] < 0 ? d_to_b_t((xs.first - x.v[0]) / omega.v[0], low_x)
+                           : d_to_b_t(huge, high_x);
+  extents_t const ys = cell_extents(cell, Y);
+  d_to_b_t const dy =
+      omega.v[1] > 0
+          ? d_to_b_t((ys.second - x.v[1]) / omega.v[1], high_y)
+          : omega.v[1] < 0 ? d_to_b_t((ys.first - x.v[1]) / omega.v[1], low_y)
+                           : d_to_b_t(huge, high_y);
+
+  extents_t const zs = cell_extents(cell, Z);
+  d_to_b_t const dz =
+      omega.v[2] > 0
+          ? d_to_b_t((zs.second - x.v[2]) / omega.v[2], high_z)
+          : omega.v[2] < 0 ? d_to_b_t((zs.first - x.v[2]) / omega.v[2], low_z)
+                           : d_to_b_t(huge, high_z);
+
+  auto comp = [](d_to_b_t const * d1, d_to_b_t const * d2) {
+    return (d1->d) < (d2->d) ? true : false;
+  };
+
+  d_to_b_t const * result = std::min(&dx, std::min(&dy, &dz, comp), comp);
+  return *result;
+}
+
+template <typename cell_t, typename geometry_t, typename bdy_descriptor_t>
+typename Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::d_to_b_t
+Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::distance_to_bdy(
+    coord_t const & crd,
+    cell_t const cell) const
+{
+  return this->distance_to_bdy(crd.x, crd.omega, cell);
+}
+
+template <typename cell_t, typename geometry_t, typename bdy_descriptor_t>
+typename Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::coord_t
+    Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::new_coordinate(
+        vec_t<3> const & oldx,
+        vec_t<3> const & oldomega,
+        geom_t const distance) const
+{
+  coord_t newc;
+  newc.x.v[0] = oldx.v[0] + distance * oldomega.v[0];
+  newc.x.v[1] = oldx.v[1] + distance * oldomega.v[1];
+  newc.x.v[2] = oldx.v[2] + distance * oldomega.v[2];
+  newc.omega.v[0] = oldomega.v[0];
+  newc.omega.v[1] = oldomega.v[1];
+  newc.omega.v[2] = oldomega.v[2];
+  return newc;
+}  // new_coordinate
+
+template <typename cell_t, typename geometry_t, typename bdy_descriptor_t>
+typename Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::extents_t
+Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::cell_extents(
+    cell_t const cell,
+    dir_t const d) const
+{
+  ijk_T ijk(mkIJK(cell));
+  cell_t const idx = getIJKComp(ijk, d);
+  cell_t const dc = getDeltaCoord(d);
+  geom_t clow = idx * dc;
+  geom_t chigh = (idx + 1) * dc;
+  return extents_t(clow, chigh);
+  // return extents_t(m_bdys[cell-1],m_bdys[cell]);
+}
+
+template <typename cell_t, typename geometry_t, typename bdy_descriptor_t>
+template <typename RNG_T>
+typename Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::Vector
+Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::sample_direction(
+    RNG_T & rng)
+{
+  geom_t const ctheta = geom_t(2) * rng.random() - geom_t(1);
+  geom_t const phi = geom_t(2) * pi * rng.random();
+  geom_t const stheta = std::sqrt(1 - ctheta * ctheta);
+  geom_t const cphi = std::cos(phi);
+  geom_t const sphi = std::sin(phi);
+  Vector v;
+  v.v = {{stheta * cphi, stheta * sphi, ctheta}};
+  return v;
+}
+
+template <typename cell_t, typename geometry_t, typename bdy_descriptor_t>
+template <typename RNG_T>
+typename Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::Vector
+Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::sample_position(
+    RNG_T & rng,
+    cell_t const cell) const
+{
+  Vector coord;
+  extents_t xs = cell_extents(cell, X);
+  extents_t ys = cell_extents(cell, Y);
+  extents_t zs = cell_extents(cell, Z);
+  coord.v[0] = xs.first + rng.random() * (xs.second - xs.first);
+
+  coord.v[1] = ys.first + rng.random() * (ys.second - ys.first);
+
+  coord.v[2] = zs.first + rng.random() * (zs.second - zs.first);
+  return coord;
+}  // sample_position
+
+template <typename cell_t, typename geometry_t, typename bdy_descriptor_t>
+cell_t
+Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::cell_across_face(
+    cell_t const cell,
+    face_t face) const
+{
+  // convert to i,j,k
+  ijk_T const ijkIn(mkIJK(cell));
+  cell_t result(cell_t(0));
+  // add/subtract 1 from appropriate index
+  if(!isBoundary(cell, face)) {
+    cell_t inew = getIJKComp(ijkIn, face) + (isHigh(face) ? 1 : (-1));
+    ijk_T updd = updateIJK(ijkIn, inew, face);
+    result = toIndex(updd);
+  }
+  else {
+    // otherwise, consult boundary condition
+    bdy_desc_t const bd = this->getBC(face, cell);
+    switch(bd) {
+      case nut::bdy_types::R: result = cell; break;
+      case nut::bdy_types::V: result = vac_cell; break;
+      default:
+        std::stringstream errstr;
+        errstr << "Mesh3DCar::cell_across_face: "
+               << "unexpected boundary descriptor " << bd;
+        printf("%s:%i %s\n", __FUNCTION__, __LINE__, errstr.str().c_str());
+    }
+  }
+  return result;
+}  // cell_across_face
+
+template <typename cell_t, typename geometry_t, typename bdy_descriptor_t>
+bool
+Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::isBoundary(
+    cell_t const cidx,
+    face_t const face) const
+{
+  bool isBound(false);
+  ijk_T const ijk(mkIJK(cidx));
+  cell_t const idx = getIJKComp(ijk, face);
+  bool const ishigh(isHigh(face));
+  if(0 == idx && !ishigh) { isBound = true; }
+  else {
+    cell_t ndir = getDimSize(face);
+    if(ndir - 1 == idx && ishigh) isBound = true;
+  }
+  return isBound;
+}
+
+template <typename cell_t, typename geometry_t, typename bdy_descriptor_t>
+Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::Cartesian_3D(
+    cell_t const nx,
+    cell_t const ny,
+    cell_t const nz,
+    geom_t const dx,
+    geom_t const dy,
+    geom_t const dz,
+    vec_bdy_descs const bds)
+    : m_nx(nx),
+      m_ny(ny),
+      m_nz(nz),
+      m_dx(dx),
+      m_dy(dy),
+      m_dz(dz),
+      m_ncells(nx * ny * nz),
+      m_bdy_descs(bds)
+{
+  nut::Require(m_bdy_descs.size() == 2 * nx * ny + 2 * nx * nz + 2 * ny * nz,
+               "Cartesian_3D: Must have correct number of"
+               " boundary descriptors");
+  auto gtg = [](geom_t const x, geom_t const e, const char * s) {
+    return nut::GreaterThan(x, e, s);
+  };
+  auto gtc = [](cell_t const x, cell_t const e, const char * s) {
+    return nut::GreaterThan(x, e, s);
+  };
+  gtg(dx, 0.0, "Cartesian_3D: x cell spacing must be > 0");
+  gtg(dy, 0.0, "Cartesian_3D: y cell spacing must be > 0");
+  gtg(dz, 0.0, "Cartesian_3D: z cell spacing must be > 0");
+  gtc(nx, 0, "Cartesian_3D: nx must be > 0");
+  gtc(ny, 0, "Cartesian_3D: ny must be > 0");
+  gtc(nz, 0, "Cartesian_3D: nz must be > 0");
+}  // ctor
+
+template <typename cell_t, typename geometry_t, typename bdy_descriptor_t>
+typename Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::bdy_desc_t
+Cartesian_3D<cell_t, geometry_t, bdy_descriptor_t>::getBC(
+    face_t const face,
+    cell_t const cidx) const
+{
+  cell_t const offset(getBCOffset(face, m_nx, m_ny, m_nz));
+  ijk_T const ijk(mkIJK(cidx));
+
+  dir_t dir = static_cast<dir_t>(face % 3);
+
+  cell_t i1;
+  cell_t i2;
+  cell_t n1;
+  switch(dir) {
+    case X:
+      i1 = ijk.j;
+      i2 = ijk.k;
+      n1 = m_ny;
+      break;
+    case Y:
+      i1 = ijk.i;
+      i2 = ijk.k;
+      n1 = m_nx;
+      break;
+    case Z:
+      i1 = ijk.i;
+      i2 = ijk.j;
+      n1 = m_nx;
+      break;
+  }
+  cell_t const bcidx = getBCIndex(i1, i2, n1);
+  cell_t const index = offset + bcidx;
+  return m_bdy_descs[index];
+}  // getBC
+
+}  // namespace nut
+
+// End of file

--- a/lib/Particle.hh
+++ b/lib/Particle.hh
@@ -15,13 +15,19 @@
 
 namespace nut {
 
-template <typename fpt, typename rngt, size_t Dim = 1>
+/**\class Particle
+ * \tparam fpt: floating point type
+ *\tparam rngt: random number generator type
+ *\tparam vectort: space vector type
+ */
+template <typename fpt, typename rngt, typename vectort>
 struct Particle {
   // types and class constants
-  static const uint32_t dim = Dim;
-  typedef fpt fp_t;
-  typedef rngt rng_t;
-  typedef nut::Vec_T<fp_t, dim> vec_t;
+  // static const uint32_t dim = Dim;
+  using fp_t = fpt;
+  using rng_t = rngt;
+  using vec_t = vectort;
+  static constexpr size_t dim = vectort::dim;
 
   vec_t x;
   vec_t omega;

--- a/lib/Tally.hh
+++ b/lib/Tally.hh
@@ -22,20 +22,20 @@ namespace nut {
 /*! \brief arrays to keep track of tally in each mesh cell
  * \tparam <fp_t> {floating point type}
  */
-template <typename fp_t, size_t Dim = 1>
+template <typename fpt, size_t Dim>
 struct Tally {
   static const size_t dim = Dim;
 
-  typedef uint32_t cntr_t;  // counter type
-  typedef fp_t FP_T;
-  // typedef vec_t<Dim> vec_t;
-  typedef vec_t<dim> const & vec_cr;
-  typedef std::vector<cntr_t> vc;
-  typedef std::vector<fp_t> vf;
-  typedef std::vector<vec_t<dim>> vv;
-  typedef fp_t const & fp_cr;
-  typedef std::pair<fp_t, fp_t> esc;
-  typedef std::vector<esc> vesc;
+  using cntr_t = uint32_t;  // counter type
+  using fp_t = fpt;
+  using FP_T = fp_t;
+  using vec_cr = vec_t<dim> const &;
+  using vc = std::vector<cntr_t>;
+  using vf = std::vector<fp_t>;
+  using vv = std::vector<vec_t<dim>>;
+  using fp_cr = fp_t const &;
+  using esc = std::pair<fp_t, fp_t>;
+  using vesc = std::vector<esc>;
 
   vf energy;
   vv momentum;
@@ -186,7 +186,7 @@ struct Tally {
     return;
   }
 
-  void merge(Tally<fp_t> const & other)
+  void merge(Tally<fp_t, dim> const & other)
   {
     Require(other.n_cells() == this->n_cells(),
             "Cannot merge tallies with different sizes");

--- a/lib/Vec3D.hh
+++ b/lib/Vec3D.hh
@@ -12,12 +12,14 @@
 #include <stdint.h>
 
 namespace nut {
-template <typename fp_t, size_t dim>
+template <typename fp_t, size_t dimn>
 struct Vec_T {
   typedef fp_t const & gcr;
   typedef fp_t value_type;
   typedef fp_t * iterator;
   typedef fp_t const * const_iterator;
+
+  static constexpr size_t dim = dimn;
 
   typedef Vec_T<fp_t, dim> vec_t;
 
@@ -30,7 +32,7 @@ struct Vec_T {
 
   std::array<fp_t, dim> v;
 
-  size_t size() const { return size_t(3); }
+  constexpr size_t size() const { return size_t(3); }
 
   // Vec_T(gcr v1,gcr v2, gcr v3): v{v1,v2,v3}{}
 

--- a/lib/Velocity.hh
+++ b/lib/Velocity.hh
@@ -46,7 +46,7 @@ private:
 
 };  // Velocity
 
-template <size_t dim = 1>
+template <size_t dim>
 struct vel_t {
   vec_t<dim> v;
 };

--- a/lib/apply_event.hh
+++ b/lib/apply_event.hh
@@ -53,7 +53,7 @@ template <typename ParticleT,
           typename OpacityT,
           typename VelocityT,
           typename CensusT,
-          typename fp_t>
+          typename TallyT>
 void
 apply_event(ParticleT & p,
             events::Event const & event,
@@ -61,11 +61,12 @@ apply_event(ParticleT & p,
             MeshT const & mesh,
             OpacityT const & opacity,
             VelocityT const & velocity,
-            Tally<fp_t> & tally,
+            TallyT & tally,
             CensusT & census,
-            fp_t const alpha = fp_t(2.0))
+            typename TallyT::fp_t const alpha = typename TallyT::fp_t(2.0))
 {
   using namespace events;
+  using fp_t = typename TallyT::fp_t;
 
   cell_t const index = make_idx(p.cell, opacity.m_n_cells);
 
@@ -76,22 +77,22 @@ apply_event(ParticleT & p,
   switch(event) {
     case nucleon_abs: apply_nucleon_abs(p, tally); break;
     case nucleon_elastic_scatter:
-      apply_nucleon_elastic_scatter<ParticleT, Tally<fp_t>, VelocityT, MeshT>(
+      apply_nucleon_elastic_scatter<ParticleT, TallyT, VelocityT, MeshT>(
           p, tally, velocity);
       break;
     case electron_scatter: {
       fp_t const ebar = opacity.m_T.T_e_minus[index];
       fp_t const e_e = ebar;
       // fp_t const e_e  = gen_power_law_energy_alpha2(ebar,p.rng);
-      apply_lepton_scatter<ParticleT, Tally<fp_t>, VelocityT, MeshT>(
-          p, tally, e_e, velocity);
+      apply_lepton_scatter<ParticleT, TallyT, VelocityT, MeshT>(p, tally, e_e,
+                                                                velocity);
     } break;
     case positron_scatter: {
       fp_t const ebar = opacity.m_T.T_e_plus[index];
       fp_t const e_e = ebar;
       // fp_t const e_e  = gen_power_law_energy_alpha2(ebar,p.rng);
-      apply_lepton_scatter<ParticleT, Tally<fp_t>, VelocityT, MeshT>(
-          p, tally, e_e, velocity);
+      apply_lepton_scatter<ParticleT, TallyT, VelocityT, MeshT>(p, tally, e_e,
+                                                                velocity);
     } break;
     // case nu_e_annhilation:
     //     break;

--- a/lib/decision.hh
+++ b/lib/decision.hh
@@ -45,7 +45,7 @@ decide_event(particle_t & p,  // non-const b/c of RNG
              opacity_t const & opacity,
              velocity_t const & velocity)
 {
-  static const size_t dim(particle_t::dim);
+  constexpr size_t dim(particle_t::dim);
 
   typedef typename particle_t::fp_t fp_t;
   // Currently there are always  three top-level events considered.
@@ -122,7 +122,7 @@ decide_boundary_event(MeshT const & mesh, cell_t const cell, cell_t const face)
   using namespace bdy_types;
   using namespace events;
   Event event(null);
-  bdy_types::descriptor b_type(mesh.bdy_type(cell, face));
+  bdy_types::descriptor b_type(mesh.get_bdy_type(cell, face));
   switch(b_type) {
     case V: event = escape; break;
     case R: event = reflect; break;

--- a/lib/fileio.hh
+++ b/lib/fileio.hh
@@ -13,7 +13,7 @@
 #include <stdint.h>
 
 namespace nut {
-template <typename fp_t, size_t dim = 1>
+template <typename fp_t, size_t dim>
 struct MatStateRowP {
   uint32_t zone;
   fp_t m_encl;
@@ -39,7 +39,7 @@ struct MatStateRowP {
   fp_t lnux_pair;
   fp_t enux_pair;
 
-  bool operator==(MatStateRowP<fp_t> const & a) const
+  bool operator==(MatStateRowP<fp_t, dim> const & a) const
   {
     return zone == a.zone && m_encl == a.m_encl && radius == a.radius &&
            density == a.density && velocity == a.velocity &&
@@ -61,12 +61,12 @@ struct MatStateRowP {
 /*!\brief read a material state file into a vector of structures,
  * one structure per line. Conversion from string to number is
  * performed, but that's it. */
-template <typename fp_t, size_t dim = 1>
+template <typename fp_t, size_t dim>
 std::vector<MatStateRowP<fp_t, dim> >
 read_mat_state_file(std::istream & i);
 
 /*!\brief convert a line (string) to a MatStateRowP */
-template <typename fp_t, size_t dim = 1>
+template <typename fp_t, size_t dim>
 MatStateRowP<fp_t, dim>
 line_to_struct(std::string const & l);
 
@@ -74,13 +74,13 @@ template <typename fp_t, size_t dim>
 std::vector<MatStateRowP<fp_t, dim> >
 read_mat_state_file(std::istream & i)
 {
-  std::vector<MatStateRowP<fp_t> > v;
+  std::vector<MatStateRowP<fp_t, dim> > v;
   v.reserve(2700);
   while(!i.eof()) {
     std::string line;
     std::getline(i, line);
     if(line != "") {
-      MatStateRowP<fp_t> row = line_to_struct<fp_t>(line);
+      MatStateRowP<fp_t, dim> row = line_to_struct<fp_t, dim>(line);
       v.push_back(row);
     }
   }

--- a/lib/lorentz.hh
+++ b/lib/lorentz.hh
@@ -12,6 +12,7 @@
 #include <cmath>
 
 namespace nut {
+
 template <size_t dim>
 using EandOmega = std::pair<geom_t, vec_t<dim> >;
 
@@ -25,6 +26,46 @@ geom_t inline gamma(vec_t<dim> const v)
 {
   return 1.0 / std::sqrt(1 - dot(v, v) / (c * c));
 }
+
+namespace spec_3D_Cartesian {
+
+EandOmega<3> inline LT_to_comoving(vec_t<3> const & v_lab,
+                                   geom_t const & e_lab,
+                                   vec_t<3> const & omega_lab)
+{
+  EandOmega<3> res;
+  geom_t & e = res.first;
+  vec_t<3> & omega = res.second;
+  geom_t const vdo = dot(v_lab, omega_lab);
+  geom_t const gam = gamma(v_lab);
+  geom_t const goc = gam / c;
+  geom_t const fac = 1 - goc * vdo / (gam + 1);
+  e = gam * e_lab * (1 - vdo / c);
+  geom_t const eoec = e_lab / e;  // E_lab/E_comving
+  omega.v[0] = eoec * (omega_lab.v[0] - goc * v_lab.v[0] * fac);
+  omega.v[1] = eoec * (omega_lab.v[1] - goc * v_lab.v[1] * fac);
+  omega.v[2] = eoec * (omega_lab.v[2] - goc * v_lab.v[2] * fac);
+  return res;
+}  // LT_to_comoving
+
+EandOmega<3> inline LT_to_lab(vec_t<3> const & v_lab,
+                              geom_t const & e_com,
+                              vec_t<3> const & omega_com)
+{
+  EandOmega<3> res;
+  geom_t const vdo = dot(v_lab, omega_com);
+  geom_t const gam = gamma(v_lab);
+  geom_t const goc = gam / c;
+  geom_t const fac = 1 + goc * vdo / (gam + 1);
+  res.first = gam * e_com * (1 + vdo / c);
+  geom_t const eoec = e_com / res.first;  // E/E_com
+  res.second.v[0] = eoec * (omega_com.v[0] + goc * v_lab.v[0] * fac);
+  res.second.v[1] = eoec * (omega_com.v[1] + goc * v_lab.v[1] * fac);
+  res.second.v[2] = eoec * (omega_com.v[2] + goc * v_lab.v[2] * fac);
+  return res;
+}  // LT_to_lab
+
+}  // namespace spec_3D_Cartesian
 
 namespace spec_1D {
 

--- a/lib/sourcery.hh
+++ b/lib/sourcery.hh
@@ -126,12 +126,13 @@ gen_init_particle(mesh_t const & mesh,
   // Mean energy of Fermionic Planckian is 7 pi^4/(180 zeta(3) * (k_B T).
   // Prefactor ~3.15137
   geom_t const ebar = 3.15137 * T;
-  geom_t const urd = rng.random();
-  geom_t const r = mesh.sample_position(urd, cell);
+  // geom_t const urd = rng.random();
+  typename mesh_t::Vector const r = mesh.sample_position(rng, cell);
+  typename mesh_t::Vector const oc = mesh.sample_direction(rng);
 
-  geom_t const osd = rng.random();
+  // geom_t const osd = rng.random();
+  // geom_t const oc = 2.0 * osd - 1.0;
 
-  geom_t const oc = 2.0 * osd - 1.0;
   geom_t const ec = gen_power_law_energy(alpha, ebar, rng);
   EandOmega<dim> enol = mesh_t::LT_to_lab(v, ec, oc);
   geom_t const e = enol.first;

--- a/lib/types.hh
+++ b/lib/types.hh
@@ -48,39 +48,39 @@ enum Event {
 };
 }  // namespace events
 
-typedef double geom_t; /*^ type for geometry calculations */
+using geom_t = double; /*^ type for geometry calculations */
 
 /** \brief Our type for geometric vectors */
 template <size_t dim>
 using vec_t = Vec_T<geom_t, dim>;
 
-typedef std::vector<geom_t> vg;
+using vg = std::vector<geom_t>;
 
-typedef std::pair<events::Event, geom_t> event_n_dist;
+using event_n_dist = std::pair<events::Event, geom_t>;
 
-typedef uint32_t cell_t; /*^ cell index. Use cell_t(-1) for null cell. */
+using cell_t = uint32_t; /*^ cell index. Use cell_t(-1) for null cell. */
 
-typedef uint32_t id_t; /*^ particle index */
+using id_t = uint32_t; /*^ particle index */
 
-typedef std::vector<id_t> vid;
+using vid = std::vector<id_t>;
 
-typedef uint32_t group_t;
+using group_t = uint32_t;
 
-typedef uint32_t cntr_t;
+using cntr_t = uint32_t;
 
-typedef std::invalid_argument arg_error;
+using arg_error = std::invalid_argument;
 
-typedef std::ostream_iterator<size_t> sz_o_it;
+using sz_o_it = std::ostream_iterator<size_t>;
 
-typedef std::ostream_iterator<geom_t> ge_o_it;
+using ge_o_it = std::ostream_iterator<geom_t>;
 
-typedef nut::Philox4x32_RNG rng_t;
+using rng_t = nut::Philox4x32_RNG;
 
-typedef rng_t::ctr_t ctr_t;
+using ctr_t = rng_t::ctr_t;
 
-typedef rng_t::key_t key_t;
+using key_t = rng_t::key_t;
 
-typedef rng_t::seed_t seed_t;
+using seed_t = rng_t::seed_t;
 
 /* Neutrino species */
 enum Species {

--- a/nut.sublime-project
+++ b/nut.sublime-project
@@ -1,0 +1,14 @@
+{
+	"folders":
+	[
+		{
+			"path": "apps"
+		},
+		{
+			"path": "lib"
+		},
+		{
+			"path": "test"
+		}
+	]
+}

--- a/test/lib/expect.cc
+++ b/test/lib/expect.cc
@@ -6,29 +6,29 @@
 
 #include "expect.hh"
 
-namespace test_aux
+namespace test_aux {
+// explicit specializations for floating point.
+template <>
+void
+expect_fail<double>(double const v, double const r, std::string const & name)
 {
-    // explicit specializations for floating point.
-    template <>
-    void expect_fail<double>(double const v, double const r, std::string const & name)
-    {
-        std::streamsize const old_prec = outstr.precision();
-        outstr << std::setprecision(15);
-        outstr << name << " = " << v << ", expected " << r << std::endl;
-        outstr << std::setprecision(old_prec);
-    }
+  std::streamsize const old_prec = outstr.precision();
+  outstr << std::setprecision(15);
+  outstr << name << " = " << v << ", expected " << r << std::endl;
+  outstr << std::setprecision(old_prec);
+}
 
-    template <>
-    void expect_fail<float>(float const v, float const r, std::string const & name)
-    {
-        std::streamsize const old_prec = outstr.precision();
-        outstr << std::setprecision(7);
-        outstr << name << " = " << v << ", expected " << r << std::endl;
-        outstr << std::setprecision(old_prec);
-    }
+template <>
+void
+expect_fail<float>(float const v, float const r, std::string const & name)
+{
+  std::streamsize const old_prec = outstr.precision();
+  outstr << std::setprecision(7);
+  outstr << name << " = " << v << ", expected " << r << std::endl;
+  outstr << std::setprecision(old_prec);
+}
 
-} // test_aux::
-
+}  // namespace test_aux
 
 // version
 // $Id$

--- a/test/lib/nut_Test_Assert_off.cc
+++ b/test/lib/nut_Test_Assert_off.cc
@@ -49,7 +49,7 @@ TEST(nut_assertions, Equal_OFF)
     std::cerr << "test_2:" << __LINE__ << " Caught assertion--not expected"
               << std::endl;
   }
-return;
+  return;
 }  // test_2
 
 TEST(nut_assertions, InOpenRange_double_OFF)
@@ -71,7 +71,7 @@ TEST(nut_assertions, InOpenRange_double_OFF)
     std::cerr << "test_3:" << __LINE__ << " Caught assertion--not expected"
               << std::endl;
   }
-return;
+  return;
 }  // test_3
 
 TEST(nut_assertions, GreaterThan_double_OFF)
@@ -93,7 +93,7 @@ TEST(nut_assertions, GreaterThan_double_OFF)
     std::cerr << "test_4:" << __LINE__ << " Caught assertion--not expected"
               << std::endl;
   }
-return;
+  return;
 }  // test_4
 
 TEST(nut_assertions, InOpenRange_uint32_t_OFF)
@@ -115,7 +115,7 @@ TEST(nut_assertions, InOpenRange_uint32_t_OFF)
     std::cerr << "test_5:" << __LINE__ << " Caught assertion--not expected"
               << std::endl;
   }
-return;
+  return;
 }  // test_5
 
 TEST(nut_assertions, GreaterThan_int64_t_OFF)
@@ -137,7 +137,7 @@ TEST(nut_assertions, GreaterThan_int64_t_OFF)
     std::cerr << "test_6:" << __LINE__ << " Caught assertion--not expected"
               << std::endl;
   }
-return;
+  return;
 }  // test_6
 
 // End of file

--- a/test/lib/nut_Test_MatState.cc
+++ b/test/lib/nut_Test_MatState.cc
@@ -18,25 +18,27 @@ std::string line(
 using nut::MatState;
 using test_aux::expect;
 
-TEST(MatState, instantiation_and_initialization)
+TEST(MatState, 1D_instantiation_and_initialization)
 {
   // cf nut_Test_fileio.cc, test_3:
+  constexpr size_t dim{1};
   typedef double fp_t;
-  typedef nut::MatStateRowP<fp_t> row_t;
+  typedef nut::MatStateRowP<fp_t, dim> row_t;
   typedef std::vector<row_t> vecrow;
 
   std::stringstream instr(line);
-  vecrow rows(nut::read_mat_state_file<fp_t>(instr));
+  vecrow rows(nut::read_mat_state_file<fp_t, 1>(instr));
 
-  MatState<fp_t> state(rows);
+  MatState<fp_t, 1> state(rows);
 
   // check mat state
   // sizes of everything:
   size_t const exp_sz(1u);
-  bool sizes_ok = expect(state.density.size(), exp_sz, "density size") and
-           expect(state.luminosity.size(), exp_sz, "luminosity size") and
-           expect(state.temperature.size(), exp_sz, "temperature size") and
-           expect(state.velocity.size(), exp_sz, "velocity size");
+  bool sizes_ok =
+      expect(state.density.size(), exp_sz, "density size") and
+      expect(state.luminosity.size(), exp_sz, "luminosity size") and
+      expect(state.temperature.size(), exp_sz, "temperature size") and
+      expect(state.velocity.size(), exp_sz, "velocity size");
   EXPECT_TRUE(sizes_ok);
   // values
 
@@ -52,9 +54,10 @@ TEST(MatState, instantiation_and_initialization)
   EXPECT_TRUE(density_passed);
 
   // luminosity
-  bool luminosity_passed = expect(state.luminosity.nue[0], 1.42784e+59, "nue") and
-           expect(state.luminosity.nueb[0], 1.42784e+59, "nuebar") and
-           expect(state.luminosity.nux[0], 9.5198000000000001e+58, "nux");
+  bool luminosity_passed =
+      expect(state.luminosity.nue[0], 1.42784e+59, "nue") and
+      expect(state.luminosity.nueb[0], 1.42784e+59, "nuebar") and
+      expect(state.luminosity.nux[0], 9.5198000000000001e+58, "nux");
   EXPECT_TRUE(luminosity_passed);
 
   // temperature

--- a/test/lib/nut_Test_Mesh.cc
+++ b/test/lib/nut_Test_Mesh.cc
@@ -270,14 +270,18 @@ TEST(nut_test, Sphere_1D_sample_position_in_cell)
 
   Sp1D mesh(bdys, bdy_types);
 
-  geom_t position = mesh.sample_position(0.1, 2);
+  geom_t rns[] = {0.1};
+  bool const silent{true};
+  nut::Buffer_RNG<geom_t> rng(rns, 1, silent);
+
+  geom_t position = mesh.sample_position(rng, 2);
 
   EXPECT_TRUE(soft_expect(position, 1.193483191927337, "sampled position"));
   return;
 }  // test_10
 
 /* Distance to boundary test cases generated in Mathematica: */
-namespace{
+namespace {
 std::string const spherical_d_to_b_tests_cxx =
     "874.2153502626182 -0.03033663375173612 777.8031650087146 "
     "909.9127641144195 280.2767555431319 2\n"

--- a/test/lib/nut_Test_Mesh3D.cc
+++ b/test/lib/nut_Test_Mesh3D.cc
@@ -9,7 +9,7 @@ using nut::Equal;
 using nut::geom_t;
 typedef uint64_t cell_t;
 typedef nut::Cartesian_3D<cell_t, double> mesh_t;
-typedef mesh_t::vbd vbd;
+typedef mesh_t::vec_bdy_descs vbd;
 using test_aux::expect;
 using test_aux::soft_expect;
 
@@ -31,7 +31,7 @@ test_2_core(cell_t const nx, cell_t const ny, cell_t const nz)
 {
   vbd bds;
   nut::mkReflectBCs<mesh_t, cell_t>(bds, nx, ny, nz);
-  mesh_t mesh(1.0, nx, 1.0, ny, 1.0, nz, bds);
+  mesh_t mesh(nx, ny, nz, 1.0, 1.0, 1.0, bds);
   cell_t const n_cs(nx * ny * nz);
   bool passed = n_cs == mesh.n_cells();
   return passed;
@@ -60,7 +60,7 @@ test_3_core(geom_t const dx,
   bool passed(true);
   vbd bds;
   nut::mkReflectBCs<mesh_t, cell_t>(bds, nx, ny, nz);
-  mesh_t mesh(dx, nx, dy, ny, dz, nz, bds);
+  mesh_t mesh(nx, ny, nz, dx, dy, dz, bds);
   geom_t const exp_vol(dx * dy * dz);
   for(cell_t c = 0; c < mesh.n_cells(); ++c) {
     geom_t const volume = mesh.volume(c);
@@ -97,7 +97,7 @@ TEST(nut_mesh_3D, isBoundary_3_cell_line)
 
   vbd bds;
   nut::mkReflectBCs<mesh_t, cell_t>(bds, nx, ny, nz);
-  mesh_t mesh(dx, nx, dy, ny, dz, nz, bds);
+  mesh_t mesh(nx, ny, nz, dx, dy, dz, bds);
 
   {
     cell_t c(0);
@@ -149,7 +149,7 @@ TEST(nut_mesh_3D, isBoundary_6_cell_cluster)
 
   vbd bds;
   nut::mkReflectBCs<mesh_t, cell_t>(bds, nx, ny, nz);
-  mesh_t mesh(dx, nx, dy, ny, dz, nz, bds);
+  mesh_t mesh(nx, ny, nz, dx, dy, dz, bds);
 
   {
     cell_t c(0);  // (0,0,0)
@@ -233,7 +233,7 @@ TEST(nut_mesh_3D, cell_across_face_6_cell_cluster)
 
   vbd bds;
   nut::mkReflectBCs<mesh_t, cell_t>(bds, nx, ny, nz);
-  mesh_t mesh(dx, nx, dy, ny, dz, nz, bds);
+  mesh_t mesh(nx, ny, nz, dx, dy, dz, bds);
   auto f = [&mesh](cell_t c, mesh_t::face_t const f, cell_t const e,
                    const char * s) {
     return expect(mesh.cell_across_face(c, f), e, s);
@@ -260,42 +260,42 @@ TEST(nut_mesh_3D, cell_across_face_6_cell_cluster)
   }
   {
     cell_t c(2);
-    bool passedc2 = f(c, mesh_t::low_x, cell_t(2), "c1 low x") &&
-                    f(c, mesh_t::high_x, cell_t(2), "c1 high x") &&
-                    f(c, mesh_t::low_y, cell_t(1), "c1 low y") &&
-                    f(c, mesh_t::high_y, cell_t(2), "c1 high y") &&
-                    f(c, mesh_t::low_z, cell_t(2), "c1 low z") &&
-                    f(c, mesh_t::high_z, cell_t(5), "c1 high z");
+    bool passedc2 = f(c, mesh_t::low_x, cell_t(2), "c2 low x") &&
+                    f(c, mesh_t::high_x, cell_t(2), "c2 high x") &&
+                    f(c, mesh_t::low_y, cell_t(1), "c2 low y") &&
+                    f(c, mesh_t::high_y, cell_t(2), "c2 high y") &&
+                    f(c, mesh_t::low_z, cell_t(2), "c2 low z") &&
+                    f(c, mesh_t::high_z, cell_t(5), "c2 high z");
     EXPECT_TRUE(passedc2);
   }
   {
     cell_t c(3);
-    bool passedc3 = f(c, mesh_t::low_x, cell_t(3), "c1 low x") &&
-                    f(c, mesh_t::high_x, cell_t(3), "c1 high x") &&
-                    f(c, mesh_t::low_y, cell_t(3), "c1 low y") &&
-                    f(c, mesh_t::high_y, cell_t(4), "c1 high y") &&
-                    f(c, mesh_t::low_z, cell_t(0), "c1 low z") &&
-                    f(c, mesh_t::high_z, cell_t(3), "c1 high z");
+    bool passedc3 = f(c, mesh_t::low_x, cell_t(3), "c3 low x") &&
+                    f(c, mesh_t::high_x, cell_t(3), "c3 high x") &&
+                    f(c, mesh_t::low_y, cell_t(3), "c3 low y") &&
+                    f(c, mesh_t::high_y, cell_t(4), "c3 high y") &&
+                    f(c, mesh_t::low_z, cell_t(0), "c3 low z") &&
+                    f(c, mesh_t::high_z, cell_t(3), "c3 high z");
     EXPECT_TRUE(passedc3);
   }
   {
     cell_t c(4);
-    bool passedc4 = f(c, mesh_t::low_x, cell_t(4), "c1 low x") &&
-                    f(c, mesh_t::high_x, cell_t(4), "c1 high x") &&
-                    f(c, mesh_t::low_y, cell_t(3), "c1 low y") &&
-                    f(c, mesh_t::high_y, cell_t(5), "c1 high y") &&
-                    f(c, mesh_t::low_z, cell_t(1), "c1 low z") &&
-                    f(c, mesh_t::high_z, cell_t(4), "c1 high z");
+    bool passedc4 = f(c, mesh_t::low_x, cell_t(4), "c4 low x") &&
+                    f(c, mesh_t::high_x, cell_t(4), "c4 high x") &&
+                    f(c, mesh_t::low_y, cell_t(3), "c4 low y") &&
+                    f(c, mesh_t::high_y, cell_t(5), "c4 high y") &&
+                    f(c, mesh_t::low_z, cell_t(1), "c4 low z") &&
+                    f(c, mesh_t::high_z, cell_t(4), "c4 high z");
     EXPECT_TRUE(passedc4);
   }
   {
     cell_t c(5);
-    bool passedc5 = f(c, mesh_t::low_x, cell_t(5), "c1 low x") &&
-                    f(c, mesh_t::high_x, cell_t(5), "c1 high x") &&
-                    f(c, mesh_t::low_y, cell_t(4), "c1 low y") &&
-                    f(c, mesh_t::high_y, cell_t(5), "c1 high y") &&
-                    f(c, mesh_t::low_z, cell_t(2), "c1 low z") &&
-                    f(c, mesh_t::high_z, cell_t(5), "c1 high z");
+    bool passedc5 = f(c, mesh_t::low_x, cell_t(5), "c5 low x") &&
+                    f(c, mesh_t::high_x, cell_t(5), "c5 high x") &&
+                    f(c, mesh_t::low_y, cell_t(4), "c5 low y") &&
+                    f(c, mesh_t::high_y, cell_t(5), "c5 high y") &&
+                    f(c, mesh_t::low_z, cell_t(2), "c5 low z") &&
+                    f(c, mesh_t::high_z, cell_t(5), "c5 high z");
     EXPECT_TRUE(passedc5);
   }
   return;
@@ -317,11 +317,10 @@ TEST(nut_mesh_3D, sample_position_buffer_rng)
   cell_t const nz = 2;
   vbd bds;
   nut::mkReflectBCs<mesh_t, cell_t>(bds, nx, ny, nz);
-  mesh_t mesh(dx, nx, dy, ny, dz, nz, bds);
+  mesh_t mesh(nx, ny, nz, dx, dy, dz, bds);
 
-  mesh_t::coord_t newcrd = mesh.sample_position(rng, 0);
-  vec_t<3> x = newcrd.x;
-  vec_t<3> o = newcrd.omega;
+  mesh_t::Vector x = mesh.sample_position(rng, 0);
+  mesh_t::Vector o = mesh.sample_direction(rng);
 
   bool passed = expect(x.v[0], 1.0, "cell 0, x") &&
                 expect(x.v[1], 1.5, "cell 0, y") &&
@@ -349,7 +348,7 @@ TEST(nut_mesh_3D, distance_to_bdy)
   cell_t const nz = 2;
   vbd bds;
   nut::mkReflectBCs<mesh_t, cell_t>(bds, nx, ny, nz);
-  mesh_t mesh(dx, nx, dy, ny, dz, nz, bds);
+  mesh_t mesh(nx, ny, nz, dx, dy, dz, bds);
 
   vec_t<3> x, o;
   x.v = {{0.8, 2.9, 4.9}};
@@ -358,9 +357,9 @@ TEST(nut_mesh_3D, distance_to_bdy)
   mesh_t::d_to_b_t d2b = mesh.distance_to_bdy(crd, cell_t(0));
 
   bool passed = expect(d2b.d, 1.2, "distance") &&
-      expect(d2b.face, mesh_t::high_x, "face");
+                expect(d2b.face, mesh_t::high_x, "face");
   EXPECT_TRUE(passed);
-  return ;
+  return;
 }  // test_8
 
 // End of file

--- a/test/lib/nut_Test_Particle.cc
+++ b/test/lib/nut_Test_Particle.cc
@@ -2,6 +2,7 @@
 
 #include "Particle.hh"
 #include "RNG.hh"
+#include "Vec3D.hh"
 #include "gtest/gtest.h"
 
 TEST(nut_Particle, instantiation)
@@ -10,7 +11,10 @@ TEST(nut_Particle, instantiation)
   typedef uint32_t rng_t;
   typedef double fp_t;
 
-  typedef nut::Particle<fp_t, rng_t, 1> part_t;
+  constexpr size_t dim = 1;
+  using Vector = nut::Vec_T<double, dim>;
+
+  typedef nut::Particle<fp_t, rng_t, Vector> part_t;
 
   fp_t x(1.0);
   fp_t omega(1.0);
@@ -24,7 +28,7 @@ TEST(nut_Particle, instantiation)
 
   part_t particle({x}, {omega}, e, t, wt, cell, rng, s);
   EXPECT_TRUE(true);
-  return ;
+  return;
 }
 
 // End of file

--- a/test/lib/nut_Test_RNG.cc
+++ b/test/lib/nut_Test_RNG.cc
@@ -18,7 +18,7 @@ public:
   void dump_state(std::ostream & o) { return m_rng.dump_state(o); }
 };
 
-TEST(nut_RNG,init_inst_Buffer_RNG_float)
+TEST(nut_RNG, init_inst_Buffer_RNG_float)
 {
   bool passed(true);
 
@@ -32,7 +32,7 @@ TEST(nut_RNG,init_inst_Buffer_RNG_float)
   return;
 }  // test_1
 
-TEST(nut_RNG,use_Buffer_RNG_float)
+TEST(nut_RNG, use_Buffer_RNG_float)
 {
   bool passed(true);
 
@@ -53,7 +53,7 @@ TEST(nut_RNG,use_Buffer_RNG_float)
   return;
 }  // test_2
 
-TEST(nut_RNG,use_Buffer_RNG_double)
+TEST(nut_RNG, use_Buffer_RNG_double)
 {
   bool passed(true);
 
@@ -74,7 +74,7 @@ TEST(nut_RNG,use_Buffer_RNG_double)
   return;
 }  // test_3
 
-TEST(nut_RNG,Buffer_RNG_double_rolled_over)
+TEST(nut_RNG, Buffer_RNG_double_rolled_over)
 {
   bool passed(true);
 
@@ -97,7 +97,7 @@ TEST(nut_RNG,Buffer_RNG_double_rolled_over)
   return;
 }  // test_4
 
-TEST(nut_RNG,init_inst_LCG_RNG)
+TEST(nut_RNG, init_inst_LCG_RNG)
 {
   bool passed(true);
 
@@ -108,7 +108,7 @@ TEST(nut_RNG,init_inst_LCG_RNG)
   return;
 }  // test_5
 
-TEST(nut_RNG,use_LCG_RNG_print_a_few_values)
+TEST(nut_RNG, use_LCG_RNG_print_a_few_values)
 {
   bool passed(true);
 
@@ -158,7 +158,7 @@ checkPred(it_t first, it_t last, pred_t pred, std::string errstr)
 
 }  // namespace
 
-TEST(nut_RNG,use_LCG_RNG_draw_1e6_values_check_for_0_lt_x_lt_1)
+TEST(nut_RNG, use_LCG_RNG_draw_1e6_values_check_for_0_lt_x_lt_1)
 {
   bool passed(true);
 
@@ -183,7 +183,7 @@ TEST(nut_RNG,use_LCG_RNG_draw_1e6_values_check_for_0_lt_x_lt_1)
   return;
 }  // test_7
 
-TEST(nut_RNG,init_inst_MLCG)
+TEST(nut_RNG, init_inst_MLCG)
 {
   bool passed(true);
 
@@ -194,7 +194,7 @@ TEST(nut_RNG,init_inst_MLCG)
   return;
 }  // test_8
 
-TEST(nut_RNG,use_MLCG_print_a_few_values_seed_42)
+TEST(nut_RNG, use_MLCG_print_a_few_values_seed_42)
 {
   bool passed(true);
 
@@ -216,7 +216,7 @@ TEST(nut_RNG,use_MLCG_print_a_few_values_seed_42)
   return;
 }  // test_9
 
-TEST(nut_RNG,use_MLCG_draw_1e6_values_check_for_0_lt_x_lt_1)
+TEST(nut_RNG, use_MLCG_draw_1e6_values_check_for_0_lt_x_lt_1)
 {
   bool passed(true);
 
@@ -241,7 +241,7 @@ TEST(nut_RNG,use_MLCG_draw_1e6_values_check_for_0_lt_x_lt_1)
   return;
 }  // test_10
 
-TEST(nut_RNG,use_MLCG_test_splitting)
+TEST(nut_RNG, use_MLCG_test_splitting)
 {
   bool passed(true);
 
@@ -310,7 +310,7 @@ TEST(nut_RNG, init_inst_Philox4x32)
   return;
 }  // test_12
 
-TEST(nut_RNG,print_a_few_values)
+TEST(nut_RNG, print_a_few_values)
 {
   bool passed(true);
 
@@ -337,7 +337,7 @@ TEST(nut_RNG,print_a_few_values)
   return;
 }  // test_13
 
-TEST(nut_RNG,compatible_with_Haskell_McPhD_usage)
+TEST(nut_RNG, compatible_with_Haskell_McPhD_usage)
 {
   bool passed(true);
 

--- a/test/lib/nut_Test_Tally.cc
+++ b/test/lib/nut_Test_Tally.cc
@@ -16,15 +16,17 @@ using test_aux::comp_verb;
 using test_aux::comp_verb_iter;
 using test_aux::tallies_same;
 
+using fp_t = double;
+constexpr size_t dim = 1;
+using t_t = nut::Tally<fp_t, dim>;
+
 TEST(nut_Tally, inst_init)
 {
   bool passed(true);
 
-  typedef double fp_t;
-
   size_t n_cells(100);
 
-  nut::Tally<fp_t> tally(n_cells);
+  nut::Tally<fp_t, dim> tally(n_cells);
 
   EXPECT_TRUE(passed);
   return;
@@ -33,10 +35,10 @@ TEST(nut_Tally, inst_init)
 TEST(nut_Tally, deposit_inelastic_el_scat)
 {
   bool passed(true);
-  typedef double fp_t;
+
   size_t n_cells(100);
 
-  nut::Tally<fp_t> tally(n_cells), ref(n_cells);
+  nut::Tally<fp_t, dim> tally(n_cells), ref(n_cells);
 
   fp_t const ei(2.0), ef(1.9);
   fp_t const omega_i(1.0), omega_f(-1.0);
@@ -59,11 +61,9 @@ TEST(nut_Tally, deposit_inelastic_el_scat)
 TEST(nut_Tally, deposit_energy)
 {
   bool passed(true);
-  typedef double fp_t;
-  typedef std::vector<fp_t> vf;
-  size_t n_cells(100);
 
-  typedef nut::Tally<fp_t> t_t;
+  using vf = std::vector<fp_t>;
+  size_t n_cells(100);
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -86,12 +86,11 @@ TEST(nut_Tally, deposit_energy)
 TEST(nut_Tally, deposit_momentum_elastic)
 {
   bool passed(true);
-  typedef double fp_t;
-  // typedef std::vector<fp_t> vf;
+
+  // using vf = std::vector<fp_t>;
   size_t n_cells(100);
 
-  typedef nut::Tally<fp_t> t_t;
-  typedef t_t::vv vv;
+  using vv = t_t::vv;
 
   static const size_t dim = t_t::dim;
 
@@ -120,11 +119,10 @@ TEST(nut_Tally, deposit_momentum_elastic)
 TEST(nut_Tally, count_electron_scatter_nu_e_)
 {
   bool passed(true);
-  typedef double fp_t;
+
   size_t n_cells(100);
 
-  typedef nut::Tally<fp_t> t_t;
-  typedef t_t::vc vc;
+  using vc = t_t::vc;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -149,11 +147,10 @@ TEST(nut_Tally, count_electron_scatter_nu_e_)
 TEST(nut_Tally, count_electron_scatter_nu_e_bar_)
 {
   bool passed(true);
-  typedef double fp_t;
+
   size_t n_cells(100);
 
-  typedef nut::Tally<fp_t> t_t;
-  typedef t_t::vc vc;
+  using vc = t_t::vc;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -180,11 +177,9 @@ TEST(nut_Tally, count_electron_scatter_nu_e_bar_)
 TEST(nut_Tally, count_electron_scatter_nu_mu_)
 {
   bool passed(true);
-  typedef double fp_t;
   size_t n_cells(100);
 
-  typedef nut::Tally<fp_t> t_t;
-  typedef t_t::vc vc;
+  using vc = t_t::vc;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -209,11 +204,9 @@ TEST(nut_Tally, count_electron_scatter_nu_mu_)
 TEST(nut_Tally, count_electron_scatter_nu_mu_bar_)
 {
   bool passed(true);
-  typedef double fp_t;
   size_t n_cells(100);
 
-  typedef nut::Tally<fp_t> t_t;
-  typedef t_t::vc vc;
+  using vc = t_t::vc;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -240,11 +233,9 @@ TEST(nut_Tally, count_electron_scatter_nu_mu_bar_)
 TEST(nut_Tally, count_electron_scatter_nu_tau_)
 {
   bool passed(true);
-  typedef double fp_t;
   size_t n_cells(100);
 
-  typedef nut::Tally<fp_t> t_t;
-  typedef t_t::vc vc;
+  using vc = t_t::vc;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -269,11 +260,9 @@ TEST(nut_Tally, count_electron_scatter_nu_tau_)
 TEST(nut_Tally, count_electron_scatter_nu_tau_bar_)
 {
   bool passed(true);
-  typedef double fp_t;
   size_t n_cells(100);
 
-  typedef nut::Tally<fp_t> t_t;
-  typedef t_t::vc vc;
+  using vc = t_t::vc;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -300,10 +289,7 @@ TEST(nut_Tally, count_electron_scatter_nu_tau_bar_)
 TEST(nut_Tally, count_nucleon_abs_nu_e_)
 {
   bool passed(true);
-  typedef double fp_t;
   size_t n_cells(100);
-
-  typedef nut::Tally<fp_t> t_t;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -329,10 +315,7 @@ TEST(nut_Tally, count_nucleon_abs_nu_e_)
 TEST(nut_Tally, count_nucleon_abs_nu_e_bar_)
 {
   bool passed(true);
-  typedef double fp_t;
   size_t n_cells(100);
-
-  typedef nut::Tally<fp_t> t_t;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -360,11 +343,9 @@ TEST(nut_Tally, count_nucleon_abs_nu_e_bar_)
 TEST(nut_Tally, count_nucleon_elastic_scatter)
 {
   bool passed(true);
-  typedef double fp_t;
   size_t n_cells(100);
 
-  typedef nut::Tally<fp_t> t_t;
-  typedef t_t::vc vc;
+  using vc = t_t::vc;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -388,10 +369,7 @@ TEST(nut_Tally, count_nucleon_elastic_scatter)
 TEST(nut_Tally, count_escape)
 {
   bool passed(true);
-  typedef double fp_t;
   size_t n_cells(100);
-
-  typedef nut::Tally<fp_t> t_t;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -421,10 +399,7 @@ TEST(nut_Tally, count_escape)
 TEST(nut_Tally, count_reflect)
 {
   bool passed(true);
-  typedef double fp_t;
   size_t n_cells(100);
-
-  typedef nut::Tally<fp_t> t_t;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -448,11 +423,9 @@ TEST(nut_Tally, count_reflect)
 TEST(nut_Tally, count_cell_bdy)
 {
   bool passed(true);
-  typedef double fp_t;
   size_t n_cells(100);
 
-  typedef nut::Tally<fp_t> t_t;
-  typedef t_t::vc vc;
+  using vc = t_t::vc;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -474,11 +447,9 @@ TEST(nut_Tally, count_cell_bdy)
 TEST(nut_Tally, count_cutoff)
 {
   bool passed(true);
-  typedef double fp_t;
   size_t n_cells(100);
 
-  typedef nut::Tally<fp_t> t_t;
-  typedef t_t::vc vc;
+  using vc = t_t::vc;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -500,10 +471,7 @@ TEST(nut_Tally, count_cutoff)
 TEST(nut_Tally, count_census_nu_e_)
 {
   bool passed(true);
-  typedef double fp_t;
   size_t n_cells(100);
-
-  typedef nut::Tally<fp_t> t_t;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -531,10 +499,7 @@ TEST(nut_Tally, count_census_nu_e_)
 TEST(nut_Tally, count_census_nu_e_bar_)
 {
   bool passed(true);
-  typedef double fp_t;
   size_t n_cells(100);
-
-  typedef nut::Tally<fp_t> t_t;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -564,10 +529,7 @@ TEST(nut_Tally, count_census_nu_e_bar_)
 TEST(nut_Tally, count_census_nu_mu_)
 {
   bool passed(true);
-  typedef double fp_t;
   size_t n_cells(100);
-
-  typedef nut::Tally<fp_t> t_t;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -595,10 +557,7 @@ TEST(nut_Tally, count_census_nu_mu_)
 TEST(nut_Tally, count_census_nu_mu_bar_)
 {
   bool passed(true);
-  typedef double fp_t;
   size_t n_cells(100);
-
-  typedef nut::Tally<fp_t> t_t;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -628,10 +587,7 @@ TEST(nut_Tally, count_census_nu_mu_bar_)
 TEST(nut_Tally, count_census_nu_tau_)
 {
   bool passed(true);
-  typedef double fp_t;
   size_t n_cells(100);
-
-  typedef nut::Tally<fp_t> t_t;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -659,10 +615,7 @@ TEST(nut_Tally, count_census_nu_tau_)
 TEST(nut_Tally, count_census_nu_tau_bar_)
 {
   bool passed(true);
-  typedef double fp_t;
   size_t n_cells(100);
-
-  typedef nut::Tally<fp_t> t_t;
 
   t_t tally(n_cells), ref(n_cells);
 
@@ -693,7 +646,7 @@ TEST(nut_Tally, merge)
 {
   size_t const n_cells(3);
 
-  typedef nut::Tally<double> tally_t;
+  using tally_t = nut::Tally<double, dim>;
   tally_t t1(n_cells);
   tally_t t2(n_cells);
   tally_t ref(n_cells);

--- a/test/lib/nut_Test_decide_event.cc
+++ b/test/lib/nut_Test_decide_event.cc
@@ -25,16 +25,16 @@ using nut::Species;
 using nut::vec_t;
 using nut::bdy_types::descriptor;
 
-typedef double fp_t;
-typedef std::vector<fp_t> vf;
-typedef std::vector<vec_t<1>> vec_vec;
-typedef nut::Density<fp_t> rho_t;
-typedef nut::Temperature<fp_t> T_t;
-typedef nut::Buffer_RNG<fp_t> BRNG;
-typedef nut::Opacity<fp_t> OpB;
-typedef nut::Particle<fp_t, BRNG> p_t;
-typedef nut::Sphere_1D<cell_t, geom_t, descriptor> mesh_t;
-typedef nut::Velocity<fp_t, 1> v_t;
+using fp_t = double;
+using vf = std::vector<fp_t>;
+using vec_vec = std::vector<vec_t<1>>;
+using rho_t = nut::Density<fp_t>;
+using T_t = nut::Temperature<fp_t>;
+using BRNG = nut::Buffer_RNG<fp_t>;
+using OpB = nut::Opacity<fp_t>;
+using p_t = nut::Particle<fp_t, BRNG, nut::Vec_T<fp_t, 1>>;
+using mesh_t = nut::Sphere_1D<cell_t, geom_t, descriptor>;
+using v_t = nut::Velocity<fp_t, 1>;
 size_t ncells(10);
 vf nullv(ncells, fp_t(0));
 
@@ -114,8 +114,8 @@ TEST(nut_decide_event, decide_boundary_event)
   using nut::events::Event;
 
   using nut::decide_boundary_event;
-  typedef mesh_t::vb vb;
-  typedef mesh_t::vbd vbd;
+  using vb = mesh_t::vb;
+  using vbd = mesh_t::vbd;
   // generate uniform mesh
   cell_t n_cells(10);
   vb bounds(n_cells + 1);
@@ -168,8 +168,8 @@ TEST(nut_decide_event, decide_event_stream_to_cell_boundary)
 {
   bool passed(true);
 
-  typedef mesh_t::vb vb;
-  typedef mesh_t::vbd vbd;
+  using vb = mesh_t::vb;
+  using vbd = mesh_t::vbd;
 
   using nut::decide_scatter_event;
   using nut::events::Event;
@@ -216,8 +216,8 @@ TEST(nut_decide_event, decide_event_stream_through_10_steps)
 {
   bool passed(true);
 
-  typedef mesh_t::vb vb;
-  typedef mesh_t::vbd vbd;
+  using vb = mesh_t::vb;
+  using vbd = mesh_t::vbd;
 
   using nut::decide_scatter_event;
   using nut::events::Event;
@@ -357,8 +357,8 @@ TEST(nut_decide_event, decide_event_nucleon_abs)
 
   using namespace nut::events;
 
-  typedef mesh_t::vb vb;
-  typedef mesh_t::vbd vbd;
+  using vb = mesh_t::vb;
+  using vbd = mesh_t::vbd;
   // generate uniform mesh
   cell_t n_cells(10);
   vb bounds(n_cells + 1);
@@ -425,8 +425,8 @@ TEST(nut_decide_event, decide_event_nucleon_elastic_scatter)
 
   using namespace nut::events;
 
-  typedef mesh_t::vb vb;
-  typedef mesh_t::vbd vbd;
+  using vb = mesh_t::vb;
+  using vbd = mesh_t::vbd;
   // generate uniform mesh
   cell_t n_cells(10);
   vb bounds(n_cells + 1);
@@ -482,8 +482,8 @@ TEST(nut_decide_event, decide_event_electron_scatter)
 
   using namespace nut::events;
 
-  typedef mesh_t::vb vb;
-  typedef mesh_t::vbd vbd;
+  using vb = mesh_t::vb;
+  using vbd = mesh_t::vbd;
   // generate uniform mesh
   cell_t n_cells(10);
   vb bounds(n_cells + 1);

--- a/test/lib/nut_Test_fileio.cc
+++ b/test/lib/nut_Test_fileio.cc
@@ -8,24 +8,26 @@
 #include <iostream>
 #include <sstream>
 
-namespace{
+namespace {
 std::string line(
     " 1  1.5000E-02  1.7348E+06  2.7438E+11  3.5650E+08"
     "  8.1058E+00  0.0000E+00  5.1030E+02  1.7185E+02  "
     "5.2054E+21  3.1954E+07  2.2382E+02  3.1954E+07  "
     "2.2248E+02  1.1083E+08  4.7589E+02  1.1083E+08  "
     "4.7589E+02  9.5198E+07  4.7589E+02");
-} // anonymous::
+}  // namespace
 
 using test_aux::expect;
 
 TEST(nut_fileio, line_to_struct_float)
 {
+  constexpr size_t dim = 1;
+
   bool passed(false);
   typedef float fp_t;
-  typedef nut::MatStateRowP<fp_t> row_t;
+  typedef nut::MatStateRowP<fp_t, dim> row_t;
 
-  row_t row = nut::line_to_struct<fp_t>(line);
+  row_t row = nut::line_to_struct<fp_t, dim>(line);
 
   row_t exp;
   exp.zone = 1;
@@ -83,11 +85,12 @@ TEST(nut_fileio, line_to_struct_float)
 
 TEST(nut_fileio, line_to_struct_double)
 {
+  constexpr size_t dim = 1;
   bool passed(false);
   typedef double fp_t;
-  typedef nut::MatStateRowP<fp_t> row_t;
+  typedef nut::MatStateRowP<fp_t, dim> row_t;
 
-  row_t row = nut::line_to_struct<fp_t>(line);
+  row_t row = nut::line_to_struct<fp_t, dim>(line);
 
   row_t exp;
   exp.zone = 1;
@@ -145,12 +148,13 @@ TEST(nut_fileio, line_to_struct_double)
 
 TEST(nut_fileio, read_mat_state_file_double)
 {
+  constexpr size_t dim = 1;
   bool passed(true);
   typedef double fp_t;
-  typedef nut::MatStateRowP<fp_t> row_t;
+  typedef nut::MatStateRowP<fp_t, dim> row_t;
 
   std::stringstream instr(line);
-  std::vector<row_t> rows(nut::read_mat_state_file<fp_t>(instr));
+  std::vector<row_t> rows(nut::read_mat_state_file<fp_t, dim>(instr));
 
   size_t const exp_sz(1u);
 

--- a/test/lib/nut_Test_species_name.cc
+++ b/test/lib/nut_Test_species_name.cc
@@ -5,7 +5,7 @@
 #include "test_aux.hh"
 #include "types.hh"
 
-TEST(species_name,nu_e)
+TEST(species_name, nu_e)
 {
   bool passed(true);
 

--- a/test/lib/nut_Test_transport_particle.cc
+++ b/test/lib/nut_Test_transport_particle.cc
@@ -22,15 +22,15 @@ using test_aux::check_same_verb;
 using test_aux::check_two_changed;
 using test_aux::comp_verb;
 
-typedef double fp_t;
-typedef nut::Buffer_RNG<fp_t> rng_t;
-typedef nut::Particle<fp_t, rng_t> p_t;
-typedef nut::Tally<fp_t> t_t;
-typedef nut::Census<p_t> c_t;
-typedef nut::Sphere_1D<cell_t, nut::geom_t, nut::bdy_types::descriptor> mesh_t;
+using fp_t = double;
+using rng_t = nut::Buffer_RNG<fp_t>;
+using p_t = nut::Particle<fp_t, rng_t, nut::Vec_T<fp_t, 1>>;
+constexpr size_t dim = 1;
+using tally_t = nut::Tally<fp_t, dim>;
+using c_t = nut::Census<p_t>;
+using mesh_t = nut::Sphere_1D<cell_t, nut::geom_t, nut::bdy_types::descriptor>;
 
-
-namespace{
+namespace {
 // bits for std particle
 fp_t const rns[] = {0.30897681610609407, 0.92436920169905545,
                     0.21932404923057958};
@@ -70,7 +70,7 @@ struct gen_bounds {
   cell_t ctr;
 };  // gen_bdy_types
 
-TEST(nut_transport,transport_1_particle)
+TEST(nutally_transport, transport_1_particle)
 {
   bool passed(true);
 
@@ -80,8 +80,8 @@ TEST(nut_transport,transport_1_particle)
   using nut::events::Event;
 
   using nut::decide_boundary_event;
-  typedef mesh_t::vb vb;
-  typedef mesh_t::vbd vbd;
+  using vb = mesh_t::vb;
+  using vbd = mesh_t::vbd;
   // generate uniform mesh
   cell_t n_cells(10);
   vb bounds(n_cells + 1);
@@ -95,7 +95,7 @@ TEST(nut_transport,transport_1_particle)
   // opacity
 
   // tally
-  nut::Tally<fp_t> tally(n_cells), ref(n_cells);
+  tally_t tally(n_cells), ref(n_cells);
 
   // census
   c_t c, c_ref;

--- a/test/lib/test_aux.cc
+++ b/test/lib/test_aux.cc
@@ -7,73 +7,77 @@
 #include "test_aux.hh"
 #include <stdio.h>
 
-namespace test_aux
+namespace test_aux {
+
+bool
+test(const char * target, const char * aspect, bool (*test2run)())
 {
+  pre_report(target, aspect);
+  bool passed = test2run();
+  post_report(target, aspect, passed);
+  return passed;
+}  // test
 
-    bool test( const char *target, const char *aspect, bool (*test2run)())
-    {
-        pre_report( target, aspect);
-        bool passed = test2run();
-        post_report( target, aspect, passed);
-        return passed;
-    } // test
+void
+pre_report(const char * target, const char * aspect)
+{
+  printf(
+      "----------------------------------------\n"
+      "Testing %s, %s\n",
+      target, aspect);
+  return;
+}
 
-    void pre_report( const char* target, const char* aspect)
-    {
-        printf("----------------------------------------\n"
-               "Testing %s, %s\n", target, aspect);
-        return;
-    }
+void
+post_report(const char * target, const char * aspect, bool passed)
+{
+  if(passed) {
+    printf(
+        "Test of %s, %s PASSED\n"
+        "----------------------------------------\n",
+        target, aspect);
+  }
+  else {
+    printf(
+        "Test of %s, %s FAILED\n"
+        "----------------------------------------\n",
+        target, aspect);
+  }
+  return;
+}
 
-    void post_report( const char* target, const char* aspect, bool passed)
-    {
-        if(passed)
-        {
-            printf("Test of %s, %s PASSED\n"
-                   "----------------------------------------\n",
-                   target,aspect);
-        }
-        else
-        {
-            printf("Test of %s, %s FAILED\n"
-                   "----------------------------------------\n",
-                   target,aspect);
-        }
-        return;
-    } 
+bool
+test(std::string const & target, std::string const & aspect, bool (*test2run)())
+{
+  pre_report(target, aspect);
+  bool passed = test2run();
+  post_report(target, aspect, passed);
+  return passed;
+}  // test
 
-    bool test( std::string const &target, std::string const & aspect, bool (*test2run)())
-    {
-        pre_report( target, aspect);
-        bool passed = test2run();
-        post_report( target, aspect, passed);
-        return passed;
-    } // test
+void
+pre_report(std::string const & target, std::string const & aspect)
+{
+  std::cout << "----------------------------------------\n"
+            << "Testing " << target << ", " << aspect << "\n";
+  return;
+}
 
-    void pre_report( std::string const & target, std::string const & aspect)
-    {
-        std::cout << "----------------------------------------\n"
-                  << "Testing " << target << ", " << aspect << "\n";
-        return;
-    }
+void
+post_report(std::string const & target, std::string const & aspect, bool passed)
+{
+  if(passed) {
+    std::cout << "Test of " << target << ", " << aspect << " PASSED\n"
+              << "----------------------------------------\n";
+  }
+  else {
+    std::cout << "Test of " << target << ", " << aspect << " FAILED\n"
+              << "----------------------------------------\n";
+  }
+  return;
+}
 
-    void post_report( std::string const & target, std::string const & aspect, bool passed)
-    {
-        if(passed)
-        {
-            std::cout << "Test of " << target<< ", " << aspect << " PASSED\n"
-                      << "----------------------------------------\n";
-        }
-        else
-        {
-            std::cout << "Test of " << target<< ", " << aspect << " FAILED\n"
-                      << "----------------------------------------\n";
-        }
-        return;
-    } 
-
-} // test_aux::
-
+}  // namespace test_aux
 
 // version
 // $Id$


### PR DESCRIPTION
This required eliminating many default template params for dimension, fixing up the indexing on the mesh, and took advantage of the moment to move mesh implementation into another file to make the header more readable. While at it, also applied clang-format to everything.